### PR TITLE
keep track of headers complete

### DIFF
--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -175,7 +175,9 @@ impl Filter {
         let mut path = mod_rpc.headers["properties_path"].clone();
         let mut properties = String::new();
         for header in mod_rpc.headers.keys() {
-            if header.contains("properties") { properties.push_str(mod_rpc.headers[header].as_str()); }
+            if header.contains("properties") && header != "properties_path" {
+                properties.push_str(mod_rpc.headers[header].as_str());
+            }
         }
         trace = graph_utils::generate_trace_graph_from_headers(path, properties);
         return trace;
@@ -208,9 +210,9 @@ impl Filter {
                 for property in y.1.keys() {
                     if x.1.contains_key(property) && &(x.1[property]) != &(y.1[property]) { return false; }
                 }
-            return true;
+                return true;
             },
-            |x, y| x == y,
+            |x, y| return true,
         );
         if !mapping.is_none() {
             let m = mapping.unwrap();

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -100,13 +100,19 @@ impl Filter {
     pub fn store_headers(&mut self, x: Rpc) {
         // store path as well as properties
         let prop_str = format!("{uid}_properties_path", uid=x.uid);
-        if x.headers.contains_key("path") {
+        if x.headers.contains_key("properties_path") {
             if self.envoy_shared_data.contains_key(&prop_str) {
                 self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(",");
                 self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(&x.headers["properties_path"]);
+                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(";");
+                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(self.whoami.as_ref().unwrap());
             }
             else {
-                self.envoy_shared_data.insert(prop_str, x.headers["properties_path"].clone());
+                // add yourself
+                let mut cur_path = x.headers["properties_path"].clone();
+                cur_path.push_str(";");
+                cur_path.push_str(self.whoami.as_ref().unwrap());
+                self.envoy_shared_data.insert(prop_str, cur_path);
             }
         }
         for key in &self.collected_properties {
@@ -114,7 +120,6 @@ impl Filter {
             let prop_key = format!("properties_{key}", key=key);
             if x.headers.contains_key(&prop_key) {
                 if self.envoy_shared_data.contains_key(&prop_str) { // concatenate with comma if not duplicate
-                    print!("I am concatenating on!!! and my plugin is {0}\n\n\n", self.whoami.as_ref().unwrap().clone());
                     // make lists of properties
                     let properties_unified = self.envoy_shared_data[&prop_str].clone();
                     let mut properties : Vec<String> = properties_unified.split(",").map(|s| s.to_string()).collect();
@@ -129,9 +134,7 @@ impl Filter {
                     // store result
                     let property_string_to_store = properties.join(",");
                     self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store.clone());
-                    print!("I am {0} and my new envoy shared data is {1}\n\n\n", self.whoami.as_ref().unwrap().clone(), property_string_to_store);
                 } else {
-                    println!("I am {0} and I had nothing stored before, so I make my own entry containing {1}", self.whoami.as_ref().unwrap().clone(), x.headers[&prop_key].clone());
                     self.envoy_shared_data.insert(prop_str.clone(), x.headers[&prop_key].clone());
                 }
             }
@@ -143,13 +146,7 @@ impl Filter {
         if new_rpc_headers["direction"] == "response" {
             let prop_str = format!("{uid}_properties_path", uid=uid);
             if self.envoy_shared_data.contains_key(&prop_str) {
-                let all_paths = self.envoy_shared_data[&prop_str].clone();
-                let mut all_paths_vec : Vec<String> = all_paths.split(",").map(|s| s.to_string()).collect();
-                for path in &mut all_paths_vec {
-                    path.push_str(";");
-                    path.push_str(self.whoami.as_ref().unwrap().as_str());
-                }
-                new_rpc_headers.insert("properties_path".to_string(), all_paths_vec.join(","));
+                new_rpc_headers.insert("properties_path".to_string(), self.envoy_shared_data[&prop_str].clone());
             }
             else { new_rpc_headers.insert("properties_path".to_string(), self.whoami.as_ref().unwrap().clone()); }
         }

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -43,7 +43,8 @@ pub struct Filter {
     pub whoami: Option<String>,
     pub target_graph: Option<Graph<(String, HashMap<String, String>), String>>,
     pub filter_state: HashMap<String, State>,
-    internal_rpc_headers: HashMap<u64, Vec<HashMap<String, String>>>, // mapping from trace ID to headers
+    pub envoy_shared_data: HashMap<String, String>,
+    pub collected_properties: Vec<String>, //properties to collect
 }
 
 impl Filter {
@@ -53,7 +54,8 @@ impl Filter {
             whoami: None,
             target_graph: None,
             filter_state: HashMap::new(),
-            internal_rpc_headers: HashMap::<u64, Vec<HashMap<String, String>>>::new(),
+            envoy_shared_data: HashMap::<String, String>::new(),
+            collected_properties: vec!( {{#each collected_properties}}"{{{this}}}".to_string(), {{/each}} ),
          }))
     }
 
@@ -63,12 +65,18 @@ impl Filter {
         for key in string_data.keys() {
             hash.insert(key.clone(), State::new_with_str(string_data[key].clone()));
         }
-        Box::into_raw(Box::new(Filter { whoami: None, target_graph: None, filter_state: hash, internal_rpc_headers: HashMap::new() }))
-    }
+        Box::into_raw(Box::new(Filter {
+                                   whoami: None,
+                                   target_graph: None,
+                                   filter_state: hash,
+                                   envoy_shared_data: HashMap::new(),
+                                   collected_properties: vec!({{#each collected_properties}}"{{{this}}}".to_string(), {{/each}} ),
+                               }))
+     }
 
     pub fn init_filter(&mut self) {
         if self.whoami.is_none() { self.set_whoami(); assert!(self.whoami.is_some()); }
-        if self.target_graph.is_none() { self.create_target_graph(); }
+        if self.target_graph.is_none() { self.create_target_graph(); } 
         assert!(self.whoami.is_some());
     }
 
@@ -89,56 +97,72 @@ impl Filter {
         assert!(self.whoami.is_some());
     }
 
-    pub fn merge_headers(&mut self, headers: Vec<HashMap<String, String>>, new_rpc_headers: HashMap<String, String>) -> HashMap<String, String> {
-        if headers.len() == 0 {
-            return new_rpc_headers;
-        }
-        let mut to_return = HashMap::new();
-        for key in new_rpc_headers.keys() {
-            // for all routing-related keys, don't change them
-            if key == "location" || key == "direction" || key == "src" || key == "dest" {
-                to_return.insert(key.to_string(), new_rpc_headers[key].clone());
+    pub fn store_headers(&mut self, x: Rpc) {
+        // store path as well as properties
+        let prop_str = format!("{uid}_properties_path", uid=x.uid);
+        if x.headers.contains_key("path") {
+            if self.envoy_shared_data.contains_key(&prop_str) {
+                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(",");
+                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(&x.headers["properties_path"]);
+            }
+            else {
+                self.envoy_shared_data.insert(prop_str, x.headers["properties_path"].clone());
             }
         }
-        for header in headers {
-            for key in header.keys() {
-                // for properties, we get rid of duplicates
-                if key != "location"
-                          && key != "direction" 
-                          && key != "src" 
-                          && key != "dest" 
-                          { // we don't want to edit these
-                    if !to_return.contains_key(key) { to_return.insert(key.to_string(), header[key].clone()); }
-                    else {
-                        let cur_props : Vec<&str> = to_return[key].split(",").collect();
-                        let new_props : Vec<&str> = header[key].split(",").collect();
-                        let mut to_add = Vec::new();
-                        for new_prop in new_props {
-                            if !cur_props.contains(&new_prop) {
-                                to_add.push(new_prop);
-                            }
-                        }
-                        for new_prop in to_add { 
-                            to_return.get_mut(key).unwrap().push_str(",");
-                            to_return.get_mut(key).unwrap().push_str(new_prop);
-                            print!("merging {0} with {1}\n", new_prop, to_return[key]);
-                        }
-                    }  
+        for key in &self.collected_properties {
+            let prop_str = format!("{uid}_properties_{key}", uid=x.uid, key=key);
+            let prop_key = format!("properties_{key}", key=key);
+            if x.headers.contains_key(&prop_key) {
+                if self.envoy_shared_data.contains_key(&prop_str) { // concatenate with comma if not duplicate
+                    // make lists of properties
+                    let properties_unified = self.envoy_shared_data[&prop_str].clone();
+                    let mut properties : Vec<String> = properties_unified.split(",").map(|s| s.to_string()).collect();
+                    let cur_properties_unified = x.headers[&prop_key].clone();
+                    let mut cur_properties : Vec<String> = cur_properties_unified.split(",").map(|s| s.to_string()).collect();
+
+                    // merge lists and remove duplicates
+                    properties.append(&mut cur_properties);
+                    properties.sort_unstable(); // must sort for dedup to work
+                    properties.dedup();
+
+                    // store result
+                    let property_string_to_store = properties.join(",");
+                    self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store);
+                } else {
+                    self.envoy_shared_data.insert(prop_str.clone(), x.headers[&prop_key].clone());
                 }
             }
         }
-        return to_return;
     }
 
-    pub fn add_myself_to_path(&mut self, x: &mut Rpc) -> String {
-        if !x.headers.contains_key("path") {
-            x.headers.insert(String::from("path"), self.whoami.as_ref().unwrap().clone());
+    pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: HashMap<String, String>) -> HashMap<String, String> {
+        let prop_str = format!("{uid}_properties_path", uid=uid);
+        if self.envoy_shared_data.contains_key(&prop_str) {
+            new_rpc_headers.insert("path".to_string(), self.envoy_shared_data[&prop_str].clone());
+        }
+        for key in &self.collected_properties {
+            let prop_str = format!("{uid}_properties_{key}", uid=uid, key=key);
+            let prop_key = format!("properties_{key}", key=key);
+            if self.envoy_shared_data.contains_key(&prop_str) {
+                new_rpc_headers.insert(prop_key, self.envoy_shared_data[&prop_str].clone());
+            } else {
+                if new_rpc_headers["direction"] != "request" { 
+                    println!("WARNING: could not find value for {0}", prop_str); 
+                }
+            }
+        }
+        return new_rpc_headers;
+    }
+
+    pub fn add_myself_to_path(&mut self, x: &mut Rpc) {
+        if !x.headers.contains_key("properties_path") {
+            x.headers.insert(String::from("properties_path"), self.whoami.as_ref().unwrap().clone());
         }
         else {
-            x.headers.get_mut("path").unwrap().push_str(";");
-            x.headers.get_mut("path").unwrap().push_str(&self.whoami.as_ref().unwrap());
+            x.headers.get_mut("properties_path").unwrap().push_str(";");
+            x.headers.get_mut("properties_path").unwrap().push_str(&self.whoami.as_ref().unwrap());
         }
-        return x.headers["path"].clone();
+        assert!(x.headers.contains_key("properties_path"));
     }
 
     pub fn create_target_graph(&mut self) {
@@ -147,37 +171,30 @@ impl Filter {
 
     pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, HashMap<String, String>), String> {
         let trace;
-        let mut path = mod_rpc.headers["path"].clone();
-        if mod_rpc.headers.contains_key(&"properties".to_string()) {
-            trace = graph_utils::generate_trace_graph_from_headers(
-                        path, 
-                        mod_rpc.headers.get_mut(&"properties".to_string()).unwrap().to_string());
+        let mut path = mod_rpc.headers["properties_path"].clone();
+        let mut properties = String::new();
+        for header in mod_rpc.headers.keys() {
+            if header.contains("properties") { properties.push_str(mod_rpc.headers[header].as_str()); }
         }
-        else {
-            trace = graph_utils::generate_trace_graph_from_headers(path, String::new());
-        }
+        trace = graph_utils::generate_trace_graph_from_headers(path, properties);
         return trace;
     }
 
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let path = self.add_myself_to_path(&mut x);
-        if self.internal_rpc_headers.contains_key(&x.uid) {
-            self.internal_rpc_headers.get_mut(&x.uid).unwrap().push(x.headers.clone());
-        } else {
-            self.internal_rpc_headers.insert(x.uid, vec!(x.headers.clone()));
-        }
-        self.internal_rpc_headers.insert(x.uid, vec!(x.headers.clone()));
+        self.store_headers(x.clone());
         return vec!(x);
     }
 
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        if self.internal_rpc_headers.contains_key(&x.uid) {
-            assert!(x.headers.contains_key("dest"));
-            x.headers = self.merge_headers(self.internal_rpc_headers[&x.uid].clone(), x.headers);
-        } else {
-            println!("WARNING: Could not find saved headers for rpc {0}", x.uid);
-            return vec!(x);
+        x.headers = self.merge_headers(x.uid, x.headers);
+
+        // normally, starting a path is the incoming response's job
+        // however, if we are a leaf node, there was no incoming response,
+        // just an incoming request.  So we start the path
+        if !x.headers.contains_key("properties_path") {
+            self.add_myself_to_path(&mut x);
         }
+        assert!(x.headers.contains_key("properties_path"));
 
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
@@ -221,24 +238,15 @@ impl Filter {
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
-        if self.internal_rpc_headers.contains_key(&x.uid) {
-            assert!(x.headers.contains_key("dest"));
-            x.headers = self.merge_headers(self.internal_rpc_headers[&x.uid].clone(), x.headers);
-        } else {
-            println!("WARNING: Could not find saved headers for rpc {0}", x.uid);
-            return vec!(x);
-        }
+        x.headers = self.merge_headers(x.uid, x.headers);
         let prop_str;
         {{#each request_blocks}}{{{this}}} {{/each}}
         return vec!(x);
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        if self.internal_rpc_headers.contains_key(&x.uid) {
-            self.internal_rpc_headers.get_mut(&x.uid).unwrap().push(x.headers.clone());
-        } else {
-            self.internal_rpc_headers.insert(x.uid, vec!(x.headers.clone()));
-        }
+        self.add_myself_to_path(&mut x);
+        self.store_headers(x.clone());
         return vec!(x);
     }
 

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -114,6 +114,7 @@ impl Filter {
             let prop_key = format!("properties_{key}", key=key);
             if x.headers.contains_key(&prop_key) {
                 if self.envoy_shared_data.contains_key(&prop_str) { // concatenate with comma if not duplicate
+                    print!("I am concatenating on!!! and my plugin is {0}\n\n\n", self.whoami.as_ref().unwrap().clone());
                     // make lists of properties
                     let properties_unified = self.envoy_shared_data[&prop_str].clone();
                     let mut properties : Vec<String> = properties_unified.split(",").map(|s| s.to_string()).collect();
@@ -127,8 +128,10 @@ impl Filter {
 
                     // store result
                     let property_string_to_store = properties.join(",");
-                    self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store);
+                    self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store.clone());
+                    print!("I am {0} and my new envoy shared data is {1}\n\n\n", self.whoami.as_ref().unwrap().clone(), property_string_to_store);
                 } else {
+                    println!("I am {0} and I had nothing stored before, so I make my own entry containing {1}", self.whoami.as_ref().unwrap().clone(), x.headers[&prop_key].clone());
                     self.envoy_shared_data.insert(prop_str.clone(), x.headers[&prop_key].clone());
                 }
             }
@@ -136,10 +139,22 @@ impl Filter {
     }
 
     pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: HashMap<String, String>) -> HashMap<String, String> {
-        let prop_str = format!("{uid}_properties_path", uid=uid);
-        if self.envoy_shared_data.contains_key(&prop_str) {
-            new_rpc_headers.insert("path".to_string(), self.envoy_shared_data[&prop_str].clone());
+        // if we are a response, we should do path bookkeeping
+        if new_rpc_headers["direction"] == "response" {
+            let prop_str = format!("{uid}_properties_path", uid=uid);
+            if self.envoy_shared_data.contains_key(&prop_str) {
+                let all_paths = self.envoy_shared_data[&prop_str].clone();
+                let mut all_paths_vec : Vec<String> = all_paths.split(",").map(|s| s.to_string()).collect();
+                for path in &mut all_paths_vec {
+                    path.push_str(";");
+                    path.push_str(self.whoami.as_ref().unwrap().as_str());
+                }
+                new_rpc_headers.insert("properties_path".to_string(), all_paths_vec.join(","));
+            }
+            else { new_rpc_headers.insert("properties_path".to_string(), self.whoami.as_ref().unwrap().clone()); }
         }
+
+        // all other properties
         for key in &self.collected_properties {
             let prop_str = format!("{uid}_properties_{key}", uid=uid, key=key);
             let prop_key = format!("properties_{key}", key=key);
@@ -152,17 +167,6 @@ impl Filter {
             }
         }
         return new_rpc_headers;
-    }
-
-    pub fn add_myself_to_path(&mut self, x: &mut Rpc) {
-        if !x.headers.contains_key("properties_path") {
-            x.headers.insert(String::from("properties_path"), self.whoami.as_ref().unwrap().clone());
-        }
-        else {
-            x.headers.get_mut("properties_path").unwrap().push_str(";");
-            x.headers.get_mut("properties_path").unwrap().push_str(&self.whoami.as_ref().unwrap());
-        }
-        assert!(x.headers.contains_key("properties_path"));
     }
 
     pub fn create_target_graph(&mut self) {
@@ -181,6 +185,8 @@ impl Filter {
     }
 
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        let prop_str;
+        {{#each request_blocks}}{{{this}}} {{/each}}
         self.store_headers(x.clone());
         return vec!(x);
     }
@@ -188,12 +194,6 @@ impl Filter {
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
         x.headers = self.merge_headers(x.uid, x.headers);
 
-        // normally, starting a path is the incoming response's job
-        // however, if we are a leaf node, there was no incoming response,
-        // just an incoming request.  So we start the path
-        if !x.headers.contains_key("properties_path") {
-            self.add_myself_to_path(&mut x);
-        }
         assert!(x.headers.contains_key("properties_path"));
 
         // at most, we return two rpcs:  one to continue on and one to storage
@@ -239,13 +239,10 @@ impl Filter {
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
         x.headers = self.merge_headers(x.uid, x.headers);
-        let prop_str;
-        {{#each request_blocks}}{{{this}}} {{/each}}
         return vec!(x);
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        self.add_myself_to_path(&mut x);
         self.store_headers(x.clone());
         return vec!(x);
     }

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -43,6 +43,7 @@ pub struct Filter {
     pub whoami: Option<String>,
     pub target_graph: Option<Graph<(String, HashMap<String, String>), String>>,
     pub filter_state: HashMap<String, State>,
+    internal_rpc_headers: HashMap<u64, Vec<HashMap<String, String>>>, // mapping from trace ID to headers
 }
 
 impl Filter {
@@ -52,6 +53,7 @@ impl Filter {
             whoami: None,
             target_graph: None,
             filter_state: HashMap::new(),
+            internal_rpc_headers: HashMap::<u64, Vec<HashMap<String, String>>>::new(),
          }))
     }
 
@@ -61,7 +63,7 @@ impl Filter {
         for key in string_data.keys() {
             hash.insert(key.clone(), State::new_with_str(string_data[key].clone()));
         }
-        Box::into_raw(Box::new(Filter { whoami: None, target_graph: None, filter_state: hash }))
+        Box::into_raw(Box::new(Filter { whoami: None, target_graph: None, filter_state: hash, internal_rpc_headers: HashMap::new() }))
     }
 
     pub fn init_filter(&mut self) {
@@ -87,12 +89,53 @@ impl Filter {
         assert!(self.whoami.is_some());
     }
 
+    pub fn merge_headers(&mut self, headers: Vec<HashMap<String, String>>, new_rpc_headers: HashMap<String, String>) -> HashMap<String, String> {
+        if headers.len() == 0 {
+            return new_rpc_headers;
+        }
+        let mut to_return = HashMap::new();
+        for key in new_rpc_headers.keys() {
+            // for all routing-related keys, don't change them
+            if key == "location" || key == "direction" || key == "src" || key == "dest" {
+                to_return.insert(key.to_string(), new_rpc_headers[key].clone());
+            }
+        }
+        for header in headers {
+            for key in header.keys() {
+                // for properties, we get rid of duplicates
+                if key != "location"
+                          && key != "direction" 
+                          && key != "src" 
+                          && key != "dest" 
+                          { // we don't want to edit these
+                    if !to_return.contains_key(key) { to_return.insert(key.to_string(), header[key].clone()); }
+                    else {
+                        let cur_props : Vec<&str> = to_return[key].split(",").collect();
+                        let new_props : Vec<&str> = header[key].split(",").collect();
+                        let mut to_add = Vec::new();
+                        for new_prop in new_props {
+                            if !cur_props.contains(&new_prop) {
+                                to_add.push(new_prop);
+                            }
+                        }
+                        for new_prop in to_add { 
+                            to_return.get_mut(key).unwrap().push_str(",");
+                            to_return.get_mut(key).unwrap().push_str(new_prop);
+                            print!("merging {0} with {1}\n", new_prop, to_return[key]);
+                        }
+                    }  
+                }
+            }
+        }
+        return to_return;
+    }
+
     pub fn add_myself_to_path(&mut self, x: &mut Rpc) -> String {
         if !x.headers.contains_key("path") {
             x.headers.insert(String::from("path"), self.whoami.as_ref().unwrap().clone());
         }
         else {
-            x.headers.get_mut("path").unwrap().push_str(",");
+            x.headers.get_mut("path").unwrap().push_str(";");
             x.headers.get_mut("path").unwrap().push_str(&self.whoami.as_ref().unwrap());
         }
         return x.headers["path"].clone();
@@ -117,12 +160,24 @@ impl Filter {
     }
 
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        self.add_myself_to_path(&mut x);
+        let path = self.add_myself_to_path(&mut x);
+        if self.internal_rpc_headers.contains_key(&x.uid) {
+            self.internal_rpc_headers.get_mut(&x.uid).unwrap().push(x.headers.clone());
+        } else {
+            self.internal_rpc_headers.insert(x.uid, vec!(x.headers.clone()));
+        }
+        self.internal_rpc_headers.insert(x.uid, vec!(x.headers.clone()));
         return vec!(x);
     }
 
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let path = self.add_myself_to_path(&mut x);
+        if self.internal_rpc_headers.contains_key(&x.uid) {
+            assert!(x.headers.contains_key("dest"));
+            x.headers = self.merge_headers(self.internal_rpc_headers[&x.uid].clone(), x.headers);
+        } else {
+            println!("WARNING: Could not find saved headers for rpc {0}", x.uid);
+            return vec!(x);
+        }
 
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
@@ -148,7 +203,7 @@ impl Filter {
             let mut value = "0".to_string(); // dummy value
             // TODO: do return stuff
             {{#each response_blocks}}{{{this}}} {{/each}}
-            let mut result_rpc = Rpc::new_rpc(&value);
+            let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
             let mut dest = self.whoami.clone().unwrap().split("_").next().unwrap().to_string(); // do not take the _plugin affix
             dest.push_str("_storage");
             result_rpc
@@ -166,12 +221,24 @@ impl Filter {
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
+        if self.internal_rpc_headers.contains_key(&x.uid) {
+            assert!(x.headers.contains_key("dest"));
+            x.headers = self.merge_headers(self.internal_rpc_headers[&x.uid].clone(), x.headers);
+        } else {
+            println!("WARNING: Could not find saved headers for rpc {0}", x.uid);
+            return vec!(x);
+        }
         let prop_str;
         {{#each request_blocks}}{{{this}}} {{/each}}
         return vec!(x);
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        if self.internal_rpc_headers.contains_key(&x.uid) {
+            self.internal_rpc_headers.get_mut(&x.uid).unwrap().push(x.headers.clone());
+        } else {
+            self.internal_rpc_headers.insert(x.uid, vec!(x.headers.clone()));
+        }
         return vec!(x);
     }
 

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -103,7 +103,7 @@ impl CodeGenSimulator {
     }
 
     fn collect_envoy_property(&mut self, property: String) {
-        let get_prop_block = format!("prop_str = format!(\"{{whoami}}.{{property}}=={{value}},\",
+        let get_prop_block = format!("prop_str = format!(\"{{whoami}}.{{property}}=={{value}}\",
                                                       whoami=&self.whoami.as_ref().unwrap(),
                                                       property=\"{property}\",
                                                       value=self.filter_state[\"{envoy_property}\"].string_data.as_ref().unwrap().to_string());
@@ -111,6 +111,7 @@ impl CodeGenSimulator {
         let insert_hdr_block = "
         if x.headers.contains_key(\"properties\") {
             if !x.headers[\"properties\"].contains(&prop_str) { // don't add our properties if they have already been added
+                x.headers.get_mut(&\"properties\".to_string()).unwrap().push_str(\",\");
                 x.headers.get_mut(&\"properties\".to_string()).unwrap().push_str(&prop_str);
             }
         }
@@ -152,12 +153,13 @@ impl CodeGenSimulator {
         );
         self.udf_blocks.push(get_udf_vals);
 
-        let save_udf_vals = format!("let {udf_id}_str = format!(\"{{whoami}}.{{udf_id}}=={{value}},\",
+        let save_udf_vals = format!("let {udf_id}_str = format!(\"{{whoami}}.{{udf_id}}=={{value}}\",
                                                       whoami=&self.whoami.as_ref().unwrap(),
                                                       udf_id=\"{udf_id}\",
                                                       value=my_{udf_id}_value);
         if x.headers.contains_key(\"properties\") {{
             if !x.headers[\"properties\"].contains(&{udf_id}_str) {{ // don't add a udf property twice
+                x.headers.get_mut(&\"properties\".to_string()).unwrap().push_str(\",\");
                 x.headers.get_mut(&\"properties\".to_string()).unwrap().push_str(&{udf_id}_str);
             }}
         }}

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -42,6 +42,7 @@ pub struct CodeGenSimulator {
     udf_blocks: Vec<String>, // code blocks to be used in the handlebars on outgoing responses, to compute UDF before matching
     udf_table: IndexMap<String, Udf>, // where we store udf implementations
     envoy_properties_to_access_names: HashMap<String, String>,
+    collected_properties: Vec<String>, // all the properties we collect
 }
 
 impl CodeGenSimulator {
@@ -54,6 +55,7 @@ impl CodeGenSimulator {
             udf_blocks: Vec::new(),
             udf_table: IndexMap::default(),
             envoy_properties_to_access_names: HashMap::new(),
+            collected_properties: Vec::new(),
         };
         for udf in udfs {
             to_return.parse_udf(udf);
@@ -108,17 +110,17 @@ impl CodeGenSimulator {
                                                       property=\"{property}\",
                                                       value=self.filter_state[\"{envoy_property}\"].string_data.as_ref().unwrap().to_string());
                                             ", property=property, envoy_property=self.envoy_properties_to_access_names[&property]);
-        let insert_hdr_block = "
-        if x.headers.contains_key(\"properties\") {
-            if !x.headers[\"properties\"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&\"properties\".to_string()).unwrap().push_str(\",\");
-                x.headers.get_mut(&\"properties\".to_string()).unwrap().push_str(&prop_str);
-            }
-        }
-        else {
-            x.headers.insert(\"properties\".to_string(), prop_str);
-        }
-        ".to_string();
+        let insert_hdr_block = format!("
+        if x.headers.contains_key(\"properties_{property}\") {{
+            if !x.headers[\"properties_{property}\"].contains(&prop_str) {{ // don't add our properties if they have already been added
+                x.headers.get_mut(&\"properties_{property}\".to_string()).unwrap().push_str(\",\");
+                x.headers.get_mut(&\"properties_{property}\".to_string()).unwrap().push_str(&prop_str);
+            }}
+        }}
+        else {{
+            x.headers.insert(\"properties_{property}\".to_string(), prop_str);
+        }}
+        ", property=property);
         self.request_blocks.push(get_prop_block);
         self.request_blocks.push(insert_hdr_block);
     }
@@ -157,14 +159,14 @@ impl CodeGenSimulator {
                                                       whoami=&self.whoami.as_ref().unwrap(),
                                                       udf_id=\"{udf_id}\",
                                                       value=my_{udf_id}_value);
-        if x.headers.contains_key(\"properties\") {{
-            if !x.headers[\"properties\"].contains(&{udf_id}_str) {{ // don't add a udf property twice
-                x.headers.get_mut(&\"properties\".to_string()).unwrap().push_str(\",\");
-                x.headers.get_mut(&\"properties\".to_string()).unwrap().push_str(&{udf_id}_str);
+        if x.headers.contains_key(\"properties_{udf_id}\") {{
+            if !x.headers[\"properties_{udf_id}\"].contains(&{udf_id}_str) {{ // don't add a udf property twice
+                x.headers.get_mut(&\"properties_{udf_id}\".to_string()).unwrap().push_str(\",\");
+                x.headers.get_mut(&\"properties_{udf_id}\".to_string()).unwrap().push_str(&{udf_id}_str);
             }}
         }}
         else {{
-            x.headers.insert(\"properties\".to_string(), {udf_id}_str);
+            x.headers.insert(\"properties_{udf_id}\".to_string(), {udf_id}_str);
         }}
                                      
         ", udf_id=udf_id);
@@ -190,6 +192,7 @@ impl CodeGenSimulator {
                 {
                     panic!("unrecognized UDF");
                 }
+                self.collected_properties.push(map_name.clone());
                 if self
                     .envoy_properties_to_access_names
                     .contains_key(&map_name)


### PR DESCRIPTION
This keeps track of RPCs' headers as they go in and out of the node, so we can propagate our custom headers in the simulator.