### PR TITLE
Some light refactors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src/proto/treenode.rs
 bin/
 example_queries/*.cc
 example_queries/*.rs
+/.idea/

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -3,6 +3,7 @@ use indexmap::map::IndexMap;
 use regex::Regex;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::mem;
 use std::str::FromStr;
 use strum_macros::EnumString;
 
@@ -78,28 +79,26 @@ impl CodeGenSimulator {
         let re = Regex::new(
             r".*udf_type:\s+(?P<udf_type>\w+)\n.*leaf_func:\s+(?P<leaf_func>\w+)\n.*mid_func:\s+(?P<mid_func>\w+)\n.*id:\s+(?P<id>\w+)",
         ).unwrap();
-        let rust_caps = re.captures(&udf_clone);
 
-        match rust_caps {
-            Some(caps) => {
-                let udf_type = UdfType::from_str(caps.name("udf_type").unwrap().as_str()).unwrap();
-                let leaf_func = String::from(caps.name("leaf_func").unwrap().as_str());
-                let mid_func = String::from(caps.name("mid_func").unwrap().as_str());
-                let id = String::from(caps.name("id").unwrap().as_str());
+        let rust_caps = re
+            .captures(&udf_clone)
+            .expect("Rust UDF did not have proper header");
 
-                self.udf_table.insert(
-                    id.clone(),
-                    Udf {
-                        udf_type,
-                        leaf_func,
-                        mid_func,
-                        func_impl: udf,
-                        id,
-                    },
-                );
-            }
-            None => panic!("Rust UDF did not have proper header"),
-        }
+        let udf_type = UdfType::from_str(rust_caps.name("udf_type").unwrap().as_str()).unwrap();
+        let leaf_func = String::from(rust_caps.name("leaf_func").unwrap().as_str());
+        let mid_func = String::from(rust_caps.name("mid_func").unwrap().as_str());
+        let id = String::from(rust_caps.name("id").unwrap().as_str());
+
+        self.udf_table.insert(
+            id.clone(),
+            Udf {
+                udf_type,
+                leaf_func,
+                mid_func,
+                func_impl: udf,
+                id,
+            },
+        );
     }
 
     fn collect_envoy_property(&mut self, property: String) {
@@ -171,10 +170,12 @@ impl CodeGenSimulator {
     }
 
     fn get_maps(&mut self) {
-        for map in &mut self.ir.maps.clone() {
+        let mut maps = Vec::new();
+        mem::swap(&mut maps, &mut self.ir.maps);
+        for map in &maps {
             let mut map_name = map.clone();
             let mut has_period = false;
-            if map_name.chars().next().unwrap() == ".".chars().next().unwrap() {
+            if map_name.starts_with('.') {
                 map_name.remove(0);
                 has_period = true;
             }
@@ -198,6 +199,7 @@ impl CodeGenSimulator {
                 }
             }
         }
+        mem::swap(&mut maps, &mut self.ir.maps);
     }
 
     fn make_struct_filter_blocks(&mut self) {

--- a/rewrite/main.rs
+++ b/rewrite/main.rs
@@ -1,8 +1,3 @@
-extern crate clap;
-extern crate dyntracing;
-extern crate handlebars;
-extern crate input_stream;
-extern crate serde;
 use antlr_rust::common_token_stream::CommonTokenStream;
 use antlr_rust::token_factory::CommonTokenFactory;
 use antlr_rust::InputStream;
@@ -61,6 +56,7 @@ fn main() {
     // Set default log level to info
     builder.filter_level(log::LevelFilter::Trace);
     builder.init();
+
 
     let bin_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let def_filter_dir = bin_dir.join("cpp_filter/filter.cc");

--- a/rewrite/main.rs
+++ b/rewrite/main.rs
@@ -57,7 +57,6 @@ fn main() {
     builder.filter_level(log::LevelFilter::Trace);
     builder.init();
 
-
     let bin_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let def_filter_dir = bin_dir.join("cpp_filter/filter.cc");
     let compile_vals = ["sim", "cpp"];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,3 @@
-extern crate clap;
-extern crate dyntracing;
-extern crate handlebars;
-extern crate serde;
-
 use clap::{App, Arg};
 use dyntracing::{code_gen, lexer, parser, tree_fold::TreeFold};
 use handlebars::Handlebars;


### PR DESCRIPTION
Just getting acclimated to the codebase with some light refactors.
- extern crate is no longer needed in Rust 2018
- match + panic can be written with Option::expect
- Instead of cloning a vec inside self to avoid multiple mutable borrows, we can std::mem::swap it to avoid one borrow.