### PR TITLE
Add a rust  wasm filter.

### DIFF
--- a/rs_filter/Cargo.toml
+++ b/rs_filter/Cargo.toml
@@ -6,10 +6,13 @@ authors = ["Anirudh Sivaraman <sk.anirudh@gmail.com>", "Jessica Berg <jb7399@nyu
 edition = "2018"
 
 [lib]
-name = "rust_filter"
+name = "filter"
 path = "filter.rs"
 crate-type = ["cdylib"]
 
+[profile.release]
+lto = true
+
 [dependencies]
-proxy-wasm = "0.1.*"
+proxy-wasm = { version = "0.1.*", features = ["wee_alloc"] }
 log = "*"

--- a/rs_filter/Cargo.toml
+++ b/rs_filter/Cargo.toml
@@ -1,0 +1,15 @@
+
+[package]
+name = "rs_filter"
+version = "0.1.0"
+authors = ["Anirudh Sivaraman <sk.anirudh@gmail.com>", "Jessica Berg <jb7399@nyu.edu>", "Fabian Ruffy <fruffy@nyu.edu>"]
+edition = "2018"
+
+[lib]
+name = "rust_filter"
+path = "filter.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+proxy-wasm = "0.1.*"
+log = "*"

--- a/rs_filter/build.sh
+++ b/rs_filter/build.sh
@@ -1,0 +1,4 @@
+# Get nightly
+rustup target add wasm32-unknown-unknown --toolchain nightly
+# Compile the filter
+cargo +nightly build --target=wasm32-unknown-unknown --release

--- a/rs_filter/filter.rs
+++ b/rs_filter/filter.rs
@@ -1,0 +1,101 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use log::debug;
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+use std::time::Duration;
+
+#[no_mangle]
+pub fn _start() {
+    proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> { Box::new(HttpAuth) });
+}
+
+struct HttpAuth;
+
+impl HttpAuth {
+    fn fail(&mut self) {
+      debug!("auth: allowed");
+      self.send_http_response(403, vec![], Some(b"not authorized"));
+    }
+}
+
+// Implement http functions related to this request.
+// This is the core of the filter code.
+impl HttpContext for HttpAuth {
+
+    // This callback will be invoked when request headers arrive
+    fn on_http_request_headers(&mut self, _: usize) -> Action {
+        // get all the request headers
+        let headers = self.get_http_request_headers();
+        // transform them from Vec<(String,String)> to Vec<(&str,&str)>; as dispatch_http_call needs
+        // Vec<(&str,&str)>.
+        let ref_headers : Vec<(&str,&str)> = headers.iter().map(|(ref k,ref v)|(k.as_str(),v.as_str())).collect();
+
+        // Dispatch a call to the auth-cluster. Here we assume that envoy's config has a cluster
+        // named auth-cluster. We send the auth cluster all our headers, so it has context to
+        // perform auth decisions.
+        let res = self.dispatch_http_call(
+            "auth-cluster", // cluster name
+            ref_headers, // headers
+            None, // no body
+            vec![], // no trailers
+            Duration::from_secs(1), // one second timeout
+        );
+
+        // If dispatch reutrn an error, fail the request.
+        match res {
+            Err(_) =>{
+                self.fail();
+            }
+            Ok(_)  => {}
+        }
+
+        // the dispatch call is asynchronous. This means it returns immediatly, while the request
+        // happens in the background. When the response arrives `on_http_call_response` will be 
+        // called. In the mean time, we need to pause the request, so it doesn't continue upstream.
+        Action::Pause
+    }
+
+    fn on_http_response_headers(&mut self, _: usize) -> Action {
+        // Add a header on the response.
+        self.set_http_response_header("Hello", Some("world"));
+        Action::Continue
+    }
+}
+
+impl Context for HttpAuth {
+    fn on_http_call_response(&mut self, _ : u32, header_size: usize, _: usize, _: usize) {
+        // We have a response to the http call!
+
+        // if we have no headers, it means the http call failed. Fail the incoming request as well.
+        if header_size == 0 {
+            self.fail();
+            return;
+        }
+
+        // Check if the auth server returned "200", if so call `resume_http_request` so request is
+        // sent upstream.
+        // Otherwise, fail the incoming request.
+        match self.get_http_request_header(":status") {
+            Some(ref status) if status == "200"  => {
+                self.resume_http_request();
+            }
+            _ => {
+                debug!("auth: not authorized");
+                self.fail();
+            }
+        }
+    }
+}

--- a/rs_filter/filter.rs
+++ b/rs_filter/filter.rs
@@ -15,7 +15,6 @@
 use log::debug;
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
-use std::time::Duration;
 
 #[no_mangle]
 pub fn _start() {
@@ -26,46 +25,26 @@ struct HttpAuth;
 
 impl HttpAuth {
     fn fail(&mut self) {
-      debug!("auth: allowed");
-      self.send_http_response(403, vec![], Some(b"not authorized"));
+        debug!("auth: allowed");
+        self.send_http_response(403, vec![], Some(b"not authorized"));
     }
 }
 
 // Implement http functions related to this request.
 // This is the core of the filter code.
 impl HttpContext for HttpAuth {
-
     // This callback will be invoked when request headers arrive
     fn on_http_request_headers(&mut self, _: usize) -> Action {
         // get all the request headers
         let headers = self.get_http_request_headers();
         // transform them from Vec<(String,String)> to Vec<(&str,&str)>; as dispatch_http_call needs
         // Vec<(&str,&str)>.
-        let ref_headers : Vec<(&str,&str)> = headers.iter().map(|(ref k,ref v)|(k.as_str(),v.as_str())).collect();
+        let _ref_headers: Vec<(&str, &str)> = headers
+            .iter()
+            .map(|(ref k, ref v)| (k.as_str(), v.as_str()))
+            .collect();
 
-        // Dispatch a call to the auth-cluster. Here we assume that envoy's config has a cluster
-        // named auth-cluster. We send the auth cluster all our headers, so it has context to
-        // perform auth decisions.
-        let res = self.dispatch_http_call(
-            "auth-cluster", // cluster name
-            ref_headers, // headers
-            None, // no body
-            vec![], // no trailers
-            Duration::from_secs(1), // one second timeout
-        );
-
-        // If dispatch reutrn an error, fail the request.
-        match res {
-            Err(_) =>{
-                self.fail();
-            }
-            Ok(_)  => {}
-        }
-
-        // the dispatch call is asynchronous. This means it returns immediatly, while the request
-        // happens in the background. When the response arrives `on_http_call_response` will be 
-        // called. In the mean time, we need to pause the request, so it doesn't continue upstream.
-        Action::Pause
+        Action::Continue
     }
 
     fn on_http_response_headers(&mut self, _: usize) -> Action {
@@ -76,7 +55,7 @@ impl HttpContext for HttpAuth {
 }
 
 impl Context for HttpAuth {
-    fn on_http_call_response(&mut self, _ : u32, header_size: usize, _: usize, _: usize) {
+    fn on_http_call_response(&mut self, _: u32, header_size: usize, _: usize, _: usize) {
         // We have a response to the http call!
 
         // if we have no headers, it means the http call failed. Fail the incoming request as well.
@@ -89,7 +68,7 @@ impl Context for HttpAuth {
         // sent upstream.
         // Otherwise, fail the incoming request.
         match self.get_http_request_header(":status") {
-            Some(ref status) if status == "200"  => {
+            Some(ref status) if status == "200" => {
                 self.resume_http_request();
             }
             _ => {

--- a/setup.sh
+++ b/setup.sh
@@ -15,4 +15,5 @@ sudo apt update && sudo apt install bazel
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 set PATH $HOME/.cargo/bin $PATH
 rustup toolchain install nightly
-
+# install the wasm back end
+rustup target add wasm32-unknown-unknown --toolchain nightly


### PR DESCRIPTION
This is the skeleton for a Rust filter that can be compiled into WASM for envoy proxies. It is much simpler than the cpp filter and we can reuse tools written for the simulator.