### PR TITLE
Synchronize with new isomorphism

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,8 @@ After the compiler has been built, you can compile queries with the
 `target/debug/dtc -q [QUERY] -u [USER_DEFINED_FUNCTION]` command. For example,
 `target/debug/dtc -q example_queries/count.cql -u example_udfs/count.cc` compiles a counting query with the user defined function "count". The result will be stored in `cpp_filter/filter.cc`.
 
+# Examples
+target/debug/dtc -q example_queries/height.cql -u example_udfs/height.rs -o rust_filter/filter.rs -c sim -r productpage-v1
 
+target/debug/dtc -q example_queries/get_service_name.cql -o rust_filter/filter.rs -c sim -r productpage-v1
 

--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -1,21 +1,23 @@
 use rpc_lib::rpc::Rpc;
 use std::collections::HashMap;
-use petgraph::algo::isomorphic_subgraph_matching;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 use petgraph::Outgoing;
-use graph_utils::graph_utils;
+use graph_utils::utils;
+use graph_utils::iso::find_mapping_shamir_centralized;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
-
 
 // user defined functions:
 
 
 
 // This represents a piece of state of the filter
-// it either contains a user defined function, or some sort of
-// other persistent state
+// it contains information that we get from calling getValue in the real filters
+// TODO:  since we no longer use these to define UDFs, we have no need for it
+// to be anything other than a string.  We should simplify it to simply have
+// an Option<String> for every possible envoy value
+
 #[derive(Clone, Debug)]
 pub struct State {
     pub type_of_state: Option<String>,
@@ -175,25 +177,26 @@ impl Filter {
          ids_to_properties.insert("c".to_string(), HashMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
          b_hashmap.insert("service_name".to_string(), "reviews-v1".to_string());
-         self.target_graph = Some(graph_utils::generate_target_graph(vertices, edges, ids_to_properties));
+         self.target_graph = Some(utils::generate_target_graph(vertices, edges, ids_to_properties));
  
     }
 
     pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, HashMap<String, String>), String> {
         let trace;
         let mut path = mod_rpc.headers["properties_path"].clone();
-        let mut properties = String::new();
+        let mut properties = Vec::new();
         for header in mod_rpc.headers.keys() {
-            if header.contains("properties") && header != "properties_path" {
-                properties.push_str(mod_rpc.headers[header].as_str());
+            if header.contains("properties_") && header != "properties_path" {
+                properties.push(mod_rpc.headers[header].clone().replace("properties_", ""));
             }
         }
-        trace = graph_utils::generate_trace_graph_from_headers(path, properties);
+        let prop_to_trace = properties.join(",");
+        trace = utils::generate_trace_graph_from_headers(path, prop_to_trace);
         return trace;
     }
 
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let prop_str;
+        let mut prop_str;
         prop_str = format!("{whoami}.{property}=={value}",
                                                       whoami=&self.whoami.as_ref().unwrap(),
                                                       property="service_name",
@@ -240,41 +243,38 @@ impl Filter {
         
 
         let mut trace_graph = self.create_trace_graph(x.clone());
-        let mapping = isomorphic_subgraph_matching(
-            self.target_graph.as_ref().unwrap(),
+        let mapping = find_mapping_shamir_centralized(
             &trace_graph,
-            |x, y| {
-                for property in y.1.keys() {
-                    if x.1.contains_key(property) && &(x.1[property]) != &(y.1[property]) { return false; }
-                }
-                return true;
-            },
-            |x, y| return true,
+            self.target_graph.as_ref().unwrap(),
         );
         if !mapping.is_none() {
             let m = mapping.unwrap();
             let mut value = "0".to_string(); // dummy value
             // TODO: do return stuff
-            let node_ptr = graph_utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
+            let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
                if node_ptr.is_none() {
                    print!("WARNING Node a not found");
                    return vec!(x);
                }
-               let trace_node_index = NodeIndex::new(m[node_ptr.unwrap().index()]);
-               if !&trace_graph.node_weight(trace_node_index).unwrap().1.contains_key("service_name") {
-                   // we have not yet collected the return property
+               let mut trace_node_index = None;
+               for map in m {
+                   if self.target_graph.as_ref().unwrap().node_weight(map.0).unwrap().0 == "a" {
+                       trace_node_index = Some(map.1);
+                       break;
+                   }
+               }
+               if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("service_name") {
+                   // we have not yet collected the return property or have a mapping error
                    return vec!(x);
                }
-               let mut ret_service_name = &trace_graph.node_weight(trace_node_index).unwrap().1[ "service_name" ];
+               let mut ret_service_name = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "service_name" ];
 
                value = ret_service_name.to_string();
  
             let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
-            let mut dest = self.whoami.clone().unwrap().split("_").next().unwrap().to_string(); // do not take the _plugin affix
-            dest.push_str("_storage");
             result_rpc
                 .headers
-                .insert("dest".to_string(), dest);
+                .insert("dest".to_string(), "storage".to_string());
             result_rpc
                 .headers
                 .insert("direction".to_string(), "request".to_string());

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -1,13 +1,12 @@
 use rpc_lib::rpc::Rpc;
 use std::collections::HashMap;
-use petgraph::algo::isomorphic_subgraph_matching;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 use petgraph::Outgoing;
-use graph_utils::graph_utils;
+use graph_utils::utils;
+use graph_utils::iso::find_mapping_shamir_centralized;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
-
 
 // user defined functions:
 // udf_type: Scalar
@@ -23,8 +22,11 @@ fn leaf_height(_graph: Graph<(String, HashMap<String, String>), String>) -> u32 
 fn mid_height(_graph: Graph<(String, HashMap<String, String>), String>, children_responses: Vec<String>) -> u32 {
     let mut max = 0;
     for response in children_responses {
-        let response_as_u32 = response.parse::<u32>().unwrap();
-            if response_as_u32 > max { max = response_as_u32; }
+        let response_as_u32 = response.parse::<u32>();
+            match response_as_u32 {
+                Ok(num) => { if num > max { max = num; } }
+                Err(e) => { print!("error: {0}\n", e); }
+            }
     }
     return max + 1;
 }
@@ -32,8 +34,11 @@ fn mid_height(_graph: Graph<(String, HashMap<String, String>), String>, children
 
 
 // This represents a piece of state of the filter
-// it either contains a user defined function, or some sort of
-// other persistent state
+// it contains information that we get from calling getValue in the real filters
+// TODO:  since we no longer use these to define UDFs, we have no need for it
+// to be anything other than a string.  We should simplify it to simply have
+// an Option<String> for every possible envoy value
+
 #[derive(Clone, Debug)]
 pub struct State {
     pub type_of_state: Option<String>,
@@ -73,7 +78,7 @@ impl Filter {
             target_graph: None,
             filter_state: HashMap::new(),
             envoy_shared_data: HashMap::<String, String>::new(),
-            collected_properties: vec!( "height".to_string(), "service_name".to_string(),  ),
+            collected_properties: vec!( "service_name".to_string(), "height".to_string(),  ),
          }))
     }
 
@@ -88,7 +93,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: hash,
                                    envoy_shared_data: HashMap::new(),
-                                   collected_properties: vec!("height".to_string(), "service_name".to_string(),  ),
+                                   collected_properties: vec!("service_name".to_string(), "height".to_string(),  ),
                                }))
      }
 
@@ -193,25 +198,26 @@ impl Filter {
          ids_to_properties.insert("c".to_string(), HashMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
          b_hashmap.insert("service_name".to_string(), "reviews-v1".to_string());
-         self.target_graph = Some(graph_utils::generate_target_graph(vertices, edges, ids_to_properties));
+         self.target_graph = Some(utils::generate_target_graph(vertices, edges, ids_to_properties));
  
     }
 
     pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, HashMap<String, String>), String> {
         let trace;
         let mut path = mod_rpc.headers["properties_path"].clone();
-        let mut properties = String::new();
+        let mut properties = Vec::new();
         for header in mod_rpc.headers.keys() {
-            if header.contains("properties") && header != "properties_path" {
-                properties.push_str(mod_rpc.headers[header].as_str());
+            if header.contains("properties_") && header != "properties_path" {
+                properties.push(mod_rpc.headers[header].clone().replace("properties_", ""));
             }
         }
-        trace = graph_utils::generate_trace_graph_from_headers(path, properties);
+        let prop_to_trace = properties.join(",");
+        trace = utils::generate_trace_graph_from_headers(path, prop_to_trace);
         return trace;
     }
 
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let prop_str;
+        let mut prop_str;
         prop_str = format!("{whoami}.{property}=={value}",
                                                       whoami=&self.whoami.as_ref().unwrap(),
                                                       property="service_name",
@@ -242,11 +248,11 @@ impl Filter {
 
         // calculate UDFs and store result
         let my_height_value;
-    if x.headers.contains_key("path") {
+    if x.headers.contains_key("properties_path") {
             // TODO:  only create trace graph once and then add to it
             let graph = self.create_trace_graph(x.clone());
             let child_iterator = graph.neighbors_directed(
-                graph_utils::get_node_with_id(&graph, self.whoami.as_ref().unwrap().clone()).unwrap(),
+                utils::get_node_with_id(&graph, self.whoami.as_ref().unwrap().clone()).unwrap(),
                 petgraph::Outgoing);
             let mut child_values = Vec::new();
             for child in child_iterator {
@@ -265,7 +271,7 @@ impl Filter {
 
          let height_str = format!("{whoami}.{udf_id}=={value}",
                                                       whoami=&self.whoami.as_ref().unwrap(),
-                                                      udf_id="height",
+                                                      udf_id="properties_height",
                                                       value=my_height_value);
         if x.headers.contains_key("properties_height") {
             if !x.headers["properties_height"].contains(&height_str) { // don't add a udf property twice
@@ -280,41 +286,38 @@ impl Filter {
          
 
         let mut trace_graph = self.create_trace_graph(x.clone());
-        let mapping = isomorphic_subgraph_matching(
-            self.target_graph.as_ref().unwrap(),
+        let mapping = find_mapping_shamir_centralized(
             &trace_graph,
-            |x, y| {
-                for property in y.1.keys() {
-                    if x.1.contains_key(property) && &(x.1[property]) != &(y.1[property]) { return false; }
-                }
-                return true;
-            },
-            |x, y| return true,
+            self.target_graph.as_ref().unwrap(),
         );
         if !mapping.is_none() {
             let m = mapping.unwrap();
             let mut value = "0".to_string(); // dummy value
             // TODO: do return stuff
-            let node_ptr = graph_utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
+            let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
                if node_ptr.is_none() {
                    print!("WARNING Node a not found");
                    return vec!(x);
                }
-               let trace_node_index = NodeIndex::new(m[node_ptr.unwrap().index()]);
-               if !&trace_graph.node_weight(trace_node_index).unwrap().1.contains_key("height") {
-                   // we have not yet collected the return property
+               let mut trace_node_index = None;
+               for map in m {
+                   if self.target_graph.as_ref().unwrap().node_weight(map.0).unwrap().0 == "a" {
+                       trace_node_index = Some(map.1);
+                       break;
+                   }
+               }
+               if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("height") {
+                   // we have not yet collected the return property or have a mapping error
                    return vec!(x);
                }
-               let mut ret_height = &trace_graph.node_weight(trace_node_index).unwrap().1[ "height" ];
+               let mut ret_height = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "height" ];
 
                value = ret_height.to_string();
  
             let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
-            let mut dest = self.whoami.clone().unwrap().split("_").next().unwrap().to_string(); // do not take the _plugin affix
-            dest.push_str("_storage");
             result_rpc
                 .headers
-                .insert("dest".to_string(), dest);
+                .insert("dest".to_string(), "storage".to_string());
             result_rpc
                 .headers
                 .insert("direction".to_string(), "request".to_string());

--- a/example_udfs/height.rs
+++ b/example_udfs/height.rs
@@ -11,8 +11,11 @@ fn leaf_height(_graph: Graph<(String, HashMap<String, String>), String>) -> u32 
 fn mid_height(_graph: Graph<(String, HashMap<String, String>), String>, children_responses: Vec<String>) -> u32 {
     let mut max = 0;
     for response in children_responses {
-        let response_as_u32 = response.parse::<u32>().unwrap();
-            if response_as_u32 > max { max = response_as_u32; }
+        let response_as_u32 = response.parse::<u32>();
+            match response_as_u32 {
+                Ok(num) => { if num > max { max = num; } }
+                Err(e) => { print!("error: {0}\n", e); }
+            }
     }
     return max + 1;
 }

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -1,21 +1,23 @@
 use rpc_lib::rpc::Rpc;
 use std::collections::HashMap;
-use petgraph::algo::isomorphic_subgraph_matching;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 use petgraph::Outgoing;
-use graph_utils::graph_utils;
+use graph_utils::utils;
+use graph_utils::iso::find_mapping_shamir_centralized;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
-
 
 // user defined functions:
 {{#each udf_table}}{{{this.func_impl}}}{{/each}}
 
 
 // This represents a piece of state of the filter
-// it either contains a user defined function, or some sort of
-// other persistent state
+// it contains information that we get from calling getValue in the real filters
+// TODO:  since we no longer use these to define UDFs, we have no need for it
+// to be anything other than a string.  We should simplify it to simply have
+// an Option<String> for every possible envoy value
+
 #[derive(Clone, Debug)]
 pub struct State {
     pub type_of_state: Option<String>,
@@ -173,18 +175,19 @@ impl Filter {
     pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, HashMap<String, String>), String> {
         let trace;
         let mut path = mod_rpc.headers["properties_path"].clone();
-        let mut properties = String::new();
+        let mut properties = Vec::new();
         for header in mod_rpc.headers.keys() {
             if header.contains("properties") && header != "properties_path" {
-                properties.push_str(mod_rpc.headers[header].as_str());
+                properties.push(mod_rpc.headers[header].clone());
             }
         }
-        trace = graph_utils::generate_trace_graph_from_headers(path, properties);
+        let prop_to_trace = properties.join(",");
+        trace = utils::generate_trace_graph_from_headers(path, prop_to_trace);
         return trace;
     }
 
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let prop_str;
+        let mut prop_str;
         {{#each request_blocks}}{{{this}}} {{/each}}
         self.store_headers(x.clone());
         return vec!(x);
@@ -203,16 +206,9 @@ impl Filter {
         {{#each udf_blocks}}{{{this}}} {{/each}}
 
         let mut trace_graph = self.create_trace_graph(x.clone());
-        let mapping = isomorphic_subgraph_matching(
-            self.target_graph.as_ref().unwrap(),
+        let mapping = find_mapping_shamir_centralized(
             &trace_graph,
-            |x, y| {
-                for property in y.1.keys() {
-                    if x.1.contains_key(property) && &(x.1[property]) != &(y.1[property]) { return false; }
-                }
-                return true;
-            },
-            |x, y| return true,
+            self.target_graph.as_ref().unwrap(),
         );
         if !mapping.is_none() {
             let m = mapping.unwrap();

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -177,8 +177,8 @@ impl Filter {
         let mut path = mod_rpc.headers["properties_path"].clone();
         let mut properties = Vec::new();
         for header in mod_rpc.headers.keys() {
-            if header.contains("properties") && header != "properties_path" {
-                properties.push(mod_rpc.headers[header].clone());
+            if header.contains("properties_") && header != "properties_path" {
+                properties.push(mod_rpc.headers[header].clone().replace("properties_", ""));
             }
         }
         let prop_to_trace = properties.join(",");
@@ -216,11 +216,9 @@ impl Filter {
             // TODO: do return stuff
             {{#each response_blocks}}{{{this}}} {{/each}}
             let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
-            let mut dest = self.whoami.clone().unwrap().split("_").next().unwrap().to_string(); // do not take the _plugin affix
-            dest.push_str("_storage");
             result_rpc
                 .headers
-                .insert("dest".to_string(), dest);
+                .insert("dest".to_string(), "storage".to_string());
             result_rpc
                 .headers
                 .insert("direction".to_string(), "request".to_string());

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -36,9 +36,9 @@ struct Udf {
 #[derive(Serialize)]
 pub struct CodeGenSimulator {
     ir: VisitorResults,               // the IR, as defined in to_ir.rs
-    request_blocks: Vec<String>, // code blocks used in incoming requests
-    response_blocks: Vec<String>, // code blocks in outgoing responses, after matching
-    target_blocks: Vec<String>,   // code blocks to create target graph
+    request_blocks: Vec<String>,      // code blocks used in incoming requests
+    response_blocks: Vec<String>,     // code blocks in outgoing responses, after matching
+    target_blocks: Vec<String>,       // code blocks to create target graph
     udf_blocks: Vec<String>, // code blocks to be used in outgoing responses, to compute UDF before matching
     udf_table: IndexMap<String, Udf>, // where we store udf implementations
     envoy_properties_to_access_names: IndexMap<String, String>,
@@ -124,7 +124,8 @@ impl CodeGenSimulator {
     }
 
     fn collect_udf_property(&mut self, udf_id: String) {
-        let get_udf_vals = format!("let my_{id}_value;
+        let get_udf_vals = format!(
+            "let my_{id}_value;
     if x.headers.contains_key(\"properties_path\") {{
             // TODO:  only create trace graph once and then add to it
             let graph = self.create_trace_graph(x.clone());
@@ -133,7 +134,7 @@ impl CodeGenSimulator {
                 petgraph::Outgoing);
             let mut child_values = Vec::new();
             for child in child_iterator {{
-                child_values.push(graph.node_weight(child).unwrap().1[\"properties_{id}\"].clone());
+                child_values.push(graph.node_weight(child).unwrap().1[\"{id}\"].clone());
             }}
             if child_values.len() == 0 {{
                 my_{id}_value = {leaf_func}(graph);
@@ -147,9 +148,9 @@ impl CodeGenSimulator {
          }}
 
         ",
-        id=udf_id,
-        leaf_func=self.udf_table[&udf_id].leaf_func,
-        mid_func=self.udf_table[&udf_id].mid_func
+            id = udf_id,
+            leaf_func = self.udf_table[&udf_id].leaf_func,
+            mid_func = self.udf_table[&udf_id].mid_func
         );
         self.udf_blocks.push(get_udf_vals);
 


### PR DESCRIPTION
Small edits to make the filter work with the new isomorphism.  They include
1. Trace graph strips the property label off of headers when constructing trace graph, so we have "height" instead of "properties_height" in the graph itself.  This makes using the properties from the queries easier.
2. Updated sending storage RPCs so that they conform with the new syntax of simply sending to storage.  The simulator takes care of edges.
3. Updated both the use of the Shamir algorithm for isomorphism, and some of the naming changes that went along with it (graph_utils -> utils).