### PR TITLE
Group by for simulator

### DIFF
--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -8,11 +8,6 @@ use graph_utils::iso::find_mapping_shamir_centralized;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
-pub struct FerriedData {
-    set_s: IndexMap<(NodeIndex, NodeIndex), IndexMap<NodeIndex, Option<Vec<(NodeIndex, NodeIndex)>>>>,
-    trace_graph: Graph
-}
-
 // user defined functions:
 
 

--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -8,6 +8,11 @@ use graph_utils::iso::find_mapping_shamir_centralized;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
+pub struct FerriedData {
+    set_s: IndexMap<(NodeIndex, NodeIndex), IndexMap<NodeIndex, Option<Vec<(NodeIndex, NodeIndex)>>>>,
+    trace_graph: Graph
+}
+
 // user defined functions:
 
 
@@ -239,12 +244,10 @@ impl Filter {
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
         let mut have_trace_level_attributes = true;
-        let mut am_root = false;
 
         // calculate UDFs and store result, and check trace level properties
         if self.whoami.as_ref().unwrap() == "productpage-v1" {
          let mut trace_prop_str : String;
-        am_root = true;
         } 
 
         let mut trace_graph = self.create_trace_graph(x.clone());
@@ -252,7 +255,7 @@ impl Filter {
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
         );
-        if !mapping.is_none() && have_trace_level_attributes {
+        if mapping.is_some() {
             let m = mapping.unwrap();
             let mut value : String;
             // TODO: do return stuff

--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -238,38 +238,43 @@ impl Filter {
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
+        let mut have_trace_level_attributes = true;
+        let mut am_root = false;
 
         // calculate UDFs and store result
-        
+        if self.whoami.as_ref().unwrap() == "productpage-v1" {
+         let mut trace_prop_str : String;
+        am_root = true;
+        } 
 
         let mut trace_graph = self.create_trace_graph(x.clone());
         let mapping = find_mapping_shamir_centralized(
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
         );
-        if !mapping.is_none() {
+        if !mapping.is_none() && have_trace_level_attributes {
             let m = mapping.unwrap();
-            let mut value = "0".to_string(); // dummy value
+            let mut value : String;
             // TODO: do return stuff
             let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
-               if node_ptr.is_none() {
-                   print!("WARNING Node a not found");
-                   return vec!(x);
-               }
-               let mut trace_node_index = None;
-               for map in m {
-                   if self.target_graph.as_ref().unwrap().node_weight(map.0).unwrap().0 == "a" {
-                       trace_node_index = Some(map.1);
-                       break;
-                   }
-               }
-               if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("service_name") {
-                   // we have not yet collected the return property or have a mapping error
-                   return vec!(x);
-               }
-               let mut ret_service_name = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "service_name" ];
+        if node_ptr.is_none() {
+           print!("WARNING Node a not found");
+                return vec!(x);
+        }
+        let mut trace_node_index = None;
+        for map in m {
+            if self.target_graph.as_ref().unwrap().node_weight(map.0).unwrap().0 == "a" {
+                trace_node_index = Some(map.1);
+                break;
+            }
+        }
+        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("service_name") {
+            // we have not yet collected the return property or have a mapping error
+            return vec!(x);
+        }
+        let mut ret_service_name = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "service_name" ];
 
-               value = ret_service_name.to_string();
+        value = ret_service_name.to_string();
  
             let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
             result_rpc

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -245,6 +245,8 @@ impl Filter {
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
+        let mut have_trace_level_attributes = true;
+        let mut am_root = false;
 
         // calculate UDFs and store result
         let my_height_value;
@@ -283,36 +285,39 @@ impl Filter {
             x.headers.insert("properties_height".to_string(), height_str);
         }
 
-         
+         if self.whoami.as_ref().unwrap() == "productpage-v1" {
+         let mut trace_prop_str : String;
+        am_root = true;
+        } 
 
         let mut trace_graph = self.create_trace_graph(x.clone());
         let mapping = find_mapping_shamir_centralized(
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
         );
-        if !mapping.is_none() {
+        if !mapping.is_none() && have_trace_level_attributes {
             let m = mapping.unwrap();
-            let mut value = "0".to_string(); // dummy value
+            let mut value : String;
             // TODO: do return stuff
             let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
-               if node_ptr.is_none() {
-                   print!("WARNING Node a not found");
-                   return vec!(x);
-               }
-               let mut trace_node_index = None;
-               for map in m {
-                   if self.target_graph.as_ref().unwrap().node_weight(map.0).unwrap().0 == "a" {
-                       trace_node_index = Some(map.1);
-                       break;
-                   }
-               }
-               if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("height") {
-                   // we have not yet collected the return property or have a mapping error
-                   return vec!(x);
-               }
-               let mut ret_height = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "height" ];
+        if node_ptr.is_none() {
+           print!("WARNING Node a not found");
+                return vec!(x);
+        }
+        let mut trace_node_index = None;
+        for map in m {
+            if self.target_graph.as_ref().unwrap().node_weight(map.0).unwrap().0 == "a" {
+                trace_node_index = Some(map.1);
+                break;
+            }
+        }
+        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("height") {
+            // we have not yet collected the return property or have a mapping error
+            return vec!(x);
+        }
+        let mut ret_height = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "height" ];
 
-               value = ret_height.to_string();
+        value = ret_height.to_string();
  
             let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
             result_rpc

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -246,7 +246,6 @@ impl Filter {
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
         let mut have_trace_level_attributes = true;
-        let mut am_root = false;
 
         // calculate UDFs and store result, and check trace level properties
         let my_height_value;
@@ -287,7 +286,6 @@ impl Filter {
 
          if self.whoami.as_ref().unwrap() == "productpage-v1" {
          let mut trace_prop_str : String;
-        am_root = true;
         } 
 
         let mut trace_graph = self.create_trace_graph(x.clone());
@@ -295,7 +293,7 @@ impl Filter {
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
         );
-        if !mapping.is_none() && have_trace_level_attributes {
+        if mapping.is_some() {
             let m = mapping.unwrap();
             let mut value : String;
             // TODO: do return stuff

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -248,7 +248,7 @@ impl Filter {
         let mut have_trace_level_attributes = true;
         let mut am_root = false;
 
-        // calculate UDFs and store result
+        // calculate UDFs and store result, and check trace level properties
         let my_height_value;
     if x.headers.contains_key("properties_path") {
             // TODO:  only create trace graph once and then add to it

--- a/example_queries/histogram.cql
+++ b/example_queries/histogram.cql
@@ -1,1 +1,1 @@
-MATCH (a {service_name: "productpage-v1"}) RETURN a.request_size, hist
+MATCH (a {service_name: "productpage-v1"}) RETURN a.request_size, hist(a.request_size)

--- a/example_queries/histogram.cql
+++ b/example_queries/histogram.cql
@@ -1,1 +1,1 @@
-MATCH (a {service_name: "productpage-v1"}) RETURN agg(a.request_size)
+MATCH (a {service_name: "productpage-v1"}) RETURN a.request_size, hist

--- a/example_queries/request_size.rs.ref
+++ b/example_queries/request_size.rs.ref
@@ -239,12 +239,10 @@ impl Filter {
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
         let mut have_trace_level_attributes = true;
-        let mut am_root = false;
 
         // calculate UDFs and store result, and check trace level properties
         if self.whoami.as_ref().unwrap() == "productpage-v1" {
          let mut trace_prop_str : String;
-        am_root = true;
         } 
 
         let mut trace_graph = self.create_trace_graph(x.clone());
@@ -252,7 +250,7 @@ impl Filter {
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
         );
-        if !mapping.is_none() && have_trace_level_attributes {
+        if mapping.is_some() {
             let m = mapping.unwrap();
             let mut value : String;
             // TODO: do return stuff

--- a/example_queries/request_size.rs.ref
+++ b/example_queries/request_size.rs.ref
@@ -57,7 +57,7 @@ impl Filter {
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "service_name".to_string(), "service_name".to_string(),  ),
+            collected_properties: vec!( "service_name".to_string(), "request_size".to_string(),  ),
          }))
     }
 
@@ -72,7 +72,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: hash,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("service_name".to_string(), "service_name".to_string(),  ),
+                                   collected_properties: vec!("service_name".to_string(), "request_size".to_string(),  ),
                                }))
      }
 
@@ -213,17 +213,17 @@ impl Filter {
         }
          prop_str = format!("{whoami}.{property}=={value}",
                                                       whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="service_name",
-                                                      value=self.filter_state["node.metadata.WORKLOAD_NAME"].string_data.as_ref().unwrap().to_string());
+                                                      property="request_size",
+                                                      value=self.filter_state["request.total_size"].string_data.as_ref().unwrap().to_string());
                                              
-        if x.headers.contains_key("properties_service_name") {
-            if !x.headers["properties_service_name"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(&prop_str);
+        if x.headers.contains_key("properties_request_size") {
+            if !x.headers["properties_request_size"].contains(&prop_str) { // don't add our properties if they have already been added
+                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(",");
+                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(&prop_str);
             }
         }
         else {
-            x.headers.insert("properties_service_name".to_string(), prop_str);
+            x.headers.insert("properties_request_size".to_string(), prop_str);
         }
          
         self.store_headers(x.clone());
@@ -268,13 +268,13 @@ impl Filter {
                 break;
             }
         }
-        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("service_name") {
+        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request_size") {
             // we have not yet collected the return property or have a mapping error
             return vec!(x);
         }
-        let mut ret_service_name = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "service_name" ];
+        let mut ret_request_size = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
 
-        value = ret_service_name.to_string();
+        value = ret_request_size.to_string();
  
             let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
             result_rpc

--- a/example_queries/request_size_avg.cql
+++ b/example_queries/request_size_avg.cql
@@ -1,1 +1,1 @@
-MATCH (a) -[]-> (b {service_name: reviews-v1})-[]->(c) RETURN a.request_size, avg(a.request_size)
+MATCH (a) -[]-> (b {service_name: reviews-v1})-[]->(c) WHERE trace.request_size = 1 RETURN a.request_size, avg(a.request_size)

--- a/example_queries/request_size_avg.rs.ref
+++ b/example_queries/request_size_avg.rs.ref
@@ -239,16 +239,14 @@ impl Filter {
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
         let mut have_trace_level_attributes = true;
-        let mut am_root = false;
 
         // calculate UDFs and store result, and check trace level properties
         if self.whoami.as_ref().unwrap() == "productpage-v1" {
          let mut trace_prop_str : String;
-        am_root = true;
  
                 let mut trace_prop_str = "productpage-v1.request_size==1".to_string();
                 if x.headers.contains_key("properties_request_size") {
-                    if !x.headers["properties_request_size"].contains(&trace_prop_str) { have_trace_level_attributes = false; }
+                    if !x.headers["properties_request_size"].contains(&trace_prop_str) { return vec!(x); }
                 }
                         } 
 
@@ -257,7 +255,7 @@ impl Filter {
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
         );
-        if !mapping.is_none() && have_trace_level_attributes {
+        if mapping.is_some() {
             let m = mapping.unwrap();
             let mut value : String;
             // TODO: do return stuff

--- a/example_queries/request_size_avg.rs.ref
+++ b/example_queries/request_size_avg.rs.ref
@@ -57,7 +57,7 @@ impl Filter {
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "service_name".to_string(), "service_name".to_string(),  ),
+            collected_properties: vec!( "service_name".to_string(), "request_size".to_string(),  ),
          }))
     }
 
@@ -72,7 +72,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: hash,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("service_name".to_string(), "service_name".to_string(),  ),
+                                   collected_properties: vec!("service_name".to_string(), "request_size".to_string(),  ),
                                }))
      }
 
@@ -213,17 +213,17 @@ impl Filter {
         }
          prop_str = format!("{whoami}.{property}=={value}",
                                                       whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="service_name",
-                                                      value=self.filter_state["node.metadata.WORKLOAD_NAME"].string_data.as_ref().unwrap().to_string());
+                                                      property="request_size",
+                                                      value=self.filter_state["request.total_size"].string_data.as_ref().unwrap().to_string());
                                              
-        if x.headers.contains_key("properties_service_name") {
-            if !x.headers["properties_service_name"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(&prop_str);
+        if x.headers.contains_key("properties_request_size") {
+            if !x.headers["properties_request_size"].contains(&prop_str) { // don't add our properties if they have already been added
+                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(",");
+                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(&prop_str);
             }
         }
         else {
-            x.headers.insert("properties_service_name".to_string(), prop_str);
+            x.headers.insert("properties_request_size".to_string(), prop_str);
         }
          
         self.store_headers(x.clone());
@@ -245,7 +245,12 @@ impl Filter {
         if self.whoami.as_ref().unwrap() == "productpage-v1" {
          let mut trace_prop_str : String;
         am_root = true;
-        } 
+ 
+                let mut trace_prop_str = "productpage-v1.request_size==1".to_string();
+                if x.headers.contains_key("properties_request_size") {
+                    if !x.headers["properties_request_size"].contains(&trace_prop_str) { have_trace_level_attributes = false; }
+                }
+                        } 
 
         let mut trace_graph = self.create_trace_graph(x.clone());
         let mapping = find_mapping_shamir_centralized(
@@ -268,13 +273,13 @@ impl Filter {
                 break;
             }
         }
-        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("service_name") {
+        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request_size") {
             // we have not yet collected the return property or have a mapping error
             return vec!(x);
         }
-        let mut ret_service_name = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "service_name" ];
+        let mut ret_request_size = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
 
-        value = ret_service_name.to_string();
+        value = ret_request_size.to_string();
  
             let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
             result_rpc

--- a/example_queries/request_size_avg_trace_attr.cql
+++ b/example_queries/request_size_avg_trace_attr.cql
@@ -1,0 +1,1 @@
+MATCH (a) -[]-> (b {service_name: reviews-v1})-[]->(c) WHERE trace.request_size = 1 RETURN trace.request_size, avg(trace.request_size)

--- a/example_queries/request_size_avg_trace_attr.rs.ref
+++ b/example_queries/request_size_avg_trace_attr.rs.ref
@@ -57,7 +57,7 @@ impl Filter {
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "service_name".to_string(), "service_name".to_string(),  ),
+            collected_properties: vec!( "service_name".to_string(), "request_size".to_string(),  ),
          }))
     }
 
@@ -72,7 +72,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: hash,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("service_name".to_string(), "service_name".to_string(),  ),
+                                   collected_properties: vec!("service_name".to_string(), "request_size".to_string(),  ),
                                }))
      }
 
@@ -213,17 +213,17 @@ impl Filter {
         }
          prop_str = format!("{whoami}.{property}=={value}",
                                                       whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="service_name",
-                                                      value=self.filter_state["node.metadata.WORKLOAD_NAME"].string_data.as_ref().unwrap().to_string());
+                                                      property="request_size",
+                                                      value=self.filter_state["request.total_size"].string_data.as_ref().unwrap().to_string());
                                              
-        if x.headers.contains_key("properties_service_name") {
-            if !x.headers["properties_service_name"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(&prop_str);
+        if x.headers.contains_key("properties_request_size") {
+            if !x.headers["properties_request_size"].contains(&prop_str) { // don't add our properties if they have already been added
+                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(",");
+                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(&prop_str);
             }
         }
         else {
-            x.headers.insert("properties_service_name".to_string(), prop_str);
+            x.headers.insert("properties_request_size".to_string(), prop_str);
         }
          
         self.store_headers(x.clone());
@@ -245,7 +245,12 @@ impl Filter {
         if self.whoami.as_ref().unwrap() == "productpage-v1" {
          let mut trace_prop_str : String;
         am_root = true;
-        } 
+ 
+                let mut trace_prop_str = "productpage-v1.request_size==1".to_string();
+                if x.headers.contains_key("properties_request_size") {
+                    if !x.headers["properties_request_size"].contains(&trace_prop_str) { have_trace_level_attributes = false; }
+                }
+                        } 
 
         let mut trace_graph = self.create_trace_graph(x.clone());
         let mapping = find_mapping_shamir_centralized(
@@ -256,25 +261,14 @@ impl Filter {
             let m = mapping.unwrap();
             let mut value : String;
             // TODO: do return stuff
-            let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
-        if node_ptr.is_none() {
-           print!("WARNING Node a not found");
+            let trace_node_index = utils::get_node_with_id(&trace_graph, "productpage-v1".to_string());
+        if trace_node_index.is_none() {
+           print!("WARNING Node productpage-v1 not found");
                 return vec!(x);
         }
-        let mut trace_node_index = None;
-        for map in m {
-            if self.target_graph.as_ref().unwrap().node_weight(map.0).unwrap().0 == "a" {
-                trace_node_index = Some(map.1);
-                break;
-            }
-        }
-        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("service_name") {
-            // we have not yet collected the return property or have a mapping error
-            return vec!(x);
-        }
-        let mut ret_service_name = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "service_name" ];
+        let mut ret_request_size = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
 
-        value = ret_service_name.to_string();
+        value = ret_request_size.to_string();
  
             let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
             result_rpc

--- a/example_queries/request_size_avg_trace_attr.rs.ref
+++ b/example_queries/request_size_avg_trace_attr.rs.ref
@@ -239,16 +239,14 @@ impl Filter {
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
         let mut have_trace_level_attributes = true;
-        let mut am_root = false;
 
         // calculate UDFs and store result, and check trace level properties
         if self.whoami.as_ref().unwrap() == "productpage-v1" {
          let mut trace_prop_str : String;
-        am_root = true;
  
                 let mut trace_prop_str = "productpage-v1.request_size==1".to_string();
                 if x.headers.contains_key("properties_request_size") {
-                    if !x.headers["properties_request_size"].contains(&trace_prop_str) { have_trace_level_attributes = false; }
+                    if !x.headers["properties_request_size"].contains(&trace_prop_str) { return vec!(x); }
                 }
                         } 
 
@@ -257,7 +255,7 @@ impl Filter {
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
         );
-        if !mapping.is_none() && have_trace_level_attributes {
+        if mapping.is_some() {
             let m = mapping.unwrap();
             let mut value : String;
             // TODO: do return stuff

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -204,7 +204,7 @@ impl Filter {
         let mut have_trace_level_attributes = true;
         let mut am_root = false;
 
-        // calculate UDFs and store result
+        // calculate UDFs and store result, and check trace level properties
         {{#each udf_blocks}}{{{this}}} {{/each}}
 
         let mut trace_graph = self.create_trace_graph(x.clone());

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -8,6 +8,11 @@ use graph_utils::iso::find_mapping_shamir_centralized;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
+pub struct FerriedData {
+    set_s: IndexMap<(NodeIndex, NodeIndex), IndexMap<NodeIndex, Option<Vec<(NodeIndex, NodeIndex)>>>>,
+    trace_graph: Graph
+}
+
 // user defined functions:
 {{#each udf_table}}{{{this.func_impl}}}{{/each}}
 

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -8,10 +8,6 @@ use graph_utils::iso::find_mapping_shamir_centralized;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
-pub struct FerriedData {
-    set_s: IndexMap<(NodeIndex, NodeIndex), IndexMap<NodeIndex, Option<Vec<(NodeIndex, NodeIndex)>>>>,
-    trace_graph: Graph
-}
 
 // user defined functions:
 {{#each udf_table}}{{{this.func_impl}}}{{/each}}

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -8,7 +8,6 @@ use graph_utils::iso::find_mapping_shamir_centralized;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
-
 // user defined functions:
 {{#each udf_table}}{{{this.func_impl}}}{{/each}}
 

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -201,6 +201,8 @@ impl Filter {
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
+        let mut have_trace_level_attributes = true;
+        let mut am_root = false;
 
         // calculate UDFs and store result
         {{#each udf_blocks}}{{{this}}} {{/each}}
@@ -210,9 +212,9 @@ impl Filter {
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
         );
-        if !mapping.is_none() {
+        if !mapping.is_none() && have_trace_level_attributes {
             let m = mapping.unwrap();
-            let mut value = "0".to_string(); // dummy value
+            let mut value : String;
             // TODO: do return stuff
             {{#each response_blocks}}{{{this}}} {{/each}}
             let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -202,7 +202,6 @@ impl Filter {
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
         let mut have_trace_level_attributes = true;
-        let mut am_root = false;
 
         // calculate UDFs and store result, and check trace level properties
         {{#each udf_blocks}}{{{this}}} {{/each}}
@@ -212,7 +211,7 @@ impl Filter {
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
         );
-        if !mapping.is_none() && have_trace_level_attributes {
+        if mapping.is_some() {
             let m = mapping.unwrap();
             let mut value : String;
             // TODO: do return stuff

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -274,7 +274,7 @@ impl CodeGenSimulator {
         for attr_filter in &self.ir.attr_filters {
             if attr_filter.node == "trace" {
                 let mut prop = attr_filter.property.clone();
-                if prop.starts_with(".") {
+                if prop.starts_with('.') {
                     prop.remove(0);
                 }
                 let trace_filter_block = format!(
@@ -288,7 +288,7 @@ impl CodeGenSimulator {
             }
         }
 
-        let end_root_block = format!("       }}");
+        let end_root_block = "       }".to_string();
         self.udf_blocks.push(end_root_block);
     }
 
@@ -338,14 +338,13 @@ impl CodeGenSimulator {
         if self.ir.return_expr.is_none() {
             return;
         }
-        let mut entity = self.ir.return_expr.as_ref().unwrap().clone().entity;
+        let entity = self.ir.return_expr.as_ref().unwrap().clone().entity;
         let mut property = self.ir.return_expr.as_ref().unwrap().clone().property;
         if property.chars().next().unwrap() == ".".chars().next().unwrap() {
             property.remove(0);
         }
 
         if entity == "trace" {
-            entity = self.ir.root_id.clone();
             self.make_storage_rpc_value_from_trace(self.ir.root_id.clone(), property);
         } else {
             let num_struct_filters = self.ir.struct_filters.len();
@@ -370,7 +369,6 @@ impl CodeGenSimulator {
             property.remove(0);
         }
 
-        let node_id: String;
         if entity == "trace" {
             self.make_storage_rpc_value_from_trace(self.ir.root_id.clone(), property);
         } else {
@@ -429,7 +427,7 @@ mod tests {
         let result =
             get_codegen_from_query("MATCH (a) -[]-> (b)-[]->(c) RETURN a.count".to_string());
         assert!(!result.struct_filters.is_empty());
-        let codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());
+        let _codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());
     }
 
     #[test]
@@ -442,5 +440,15 @@ mod tests {
         assert!(!_codegen.target_blocks.is_empty());
         assert!(!_codegen.ir.struct_filters.is_empty());
         assert!(!_codegen.ir.aggregate.is_none());
+    }
+
+    #[test]
+    fn test_where() {
+        let result = get_codegen_from_query(
+            "MATCH (a) -[]-> (b {service_name: reviews-v1})-[]->(c) WHERE trace.request_size = 1 RETURN a.request_size, avg(a.request_size)".to_string(),
+        );
+        assert!(!result.struct_filters.is_empty());
+        let _codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());
+        assert!(!_codegen.ir.attr_filters.is_empty());
     }
 }

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -268,7 +268,7 @@ impl CodeGenSimulator {
         );
         self.udf_blocks.push(if_root_block);
         let init_trace_prop_str =
-            "        let mut trace_prop_str : String;\n        am_root = true;\n".to_string();
+            "        let mut trace_prop_str : String;\n".to_string();
         self.udf_blocks.push(init_trace_prop_str);
 
         for attr_filter in &self.ir.attr_filters {
@@ -281,7 +281,7 @@ impl CodeGenSimulator {
                 "
                 let mut trace_prop_str = \"{root_id}.{prop_name}=={value}\".to_string();
                 if x.headers.contains_key(\"properties_{prop_name}\") {{
-                    if !x.headers[\"properties_{prop_name}\"].contains(&trace_prop_str) {{ have_trace_level_attributes = false; }}
+                    if !x.headers[\"properties_{prop_name}\"].contains(&trace_prop_str) {{ return vec!(x); }}
                 }}
                 ", root_id=self.ir.root_id, prop_name=prop, value=attr_filter.value);
                 self.udf_blocks.push(trace_filter_block);

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -267,8 +267,7 @@ impl CodeGenSimulator {
             root_id = self.ir.root_id
         );
         self.udf_blocks.push(if_root_block);
-        let init_trace_prop_str =
-            "        let mut trace_prop_str : String;\n".to_string();
+        let init_trace_prop_str = "        let mut trace_prop_str : String;\n".to_string();
         self.udf_blocks.push(init_trace_prop_str);
 
         for attr_filter in &self.ir.attr_filters {

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -258,21 +258,95 @@ impl CodeGenSimulator {
     }
 
     fn make_attr_filter_blocks(&mut self) {
-        // TODO
+        // for everything except trace level attributes, the UDF/envoy property
+        // collection will make the attribute filtering happen at the same time as
+        // the struct filtering.  This is not the case for trace-level attributes
+
+        let if_root_block = format!(
+            "if self.whoami.as_ref().unwrap() == \"{root_id}\" {{\n",
+            root_id = self.ir.root_id
+        );
+        self.udf_blocks.push(if_root_block);
+        let init_trace_prop_str =
+            "        let mut trace_prop_str : String;\n        am_root = true;\n".to_string();
+        self.udf_blocks.push(init_trace_prop_str);
+
+        for attr_filter in &self.ir.attr_filters {
+            if attr_filter.node == "trace" {
+                let mut prop = attr_filter.property.clone();
+                if prop.starts_with(".") {
+                    prop.remove(0);
+                }
+                let trace_filter_block = format!(
+                "
+                let mut trace_prop_str = \"{root_id}.{prop_name}=={value}\".to_string();
+                if x.headers.contains_key(\"properties_{prop_name}\") {{
+                    if !x.headers[\"properties_{prop_name}\"].contains(&trace_prop_str) {{ have_trace_level_attributes = false; }}
+                }}
+                ", root_id=self.ir.root_id, prop_name=prop, value=attr_filter.value);
+                self.udf_blocks.push(trace_filter_block);
+            }
+        }
+
+        let end_root_block = format!("       }}");
+        self.udf_blocks.push(end_root_block);
+    }
+
+    fn make_storage_rpc_value_from_trace(&mut self, entity: String, property: String) {
+        let ret_block = format!(
+        "let trace_node_index = utils::get_node_with_id(&trace_graph, \"{node_id}\".to_string());
+        if trace_node_index.is_none() {{
+           print!(\"WARNING Node {node_id} not found\");
+                return vec!(x);
+        }}
+        let mut ret_{prop} = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ \"{prop}\" ];\n
+        value = ret_{prop}.to_string();\n",
+                node_id = entity,
+                prop = property
+        );
+
+        self.response_blocks.push(ret_block);
+    }
+    fn make_storage_rpc_value_from_target(&mut self, entity: String, property: String) {
+        let ret_block = format!(
+        "let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), \"{node_id}\".to_string());
+        if node_ptr.is_none() {{
+           print!(\"WARNING Node {node_id} not found\");
+                return vec!(x);
+        }}
+        let mut trace_node_index = None;
+        for map in m {{
+            if self.target_graph.as_ref().unwrap().node_weight(map.0).unwrap().0 == \"{node_id}\" {{
+                trace_node_index = Some(map.1);
+                break;
+            }}
+        }}
+        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key(\"{prop}\") {{
+            // we have not yet collected the return property or have a mapping error
+            return vec!(x);
+        }}
+        let mut ret_{prop} = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ \"{prop}\" ];\n
+        value = ret_{prop}.to_string();\n",
+                node_id = entity,
+                prop = property
+        );
+
+        self.response_blocks.push(ret_block);
     }
 
     fn make_return_block(&mut self) {
         if self.ir.return_expr.is_none() {
             return;
         }
-        let entity = self.ir.return_expr.as_ref().unwrap().clone().entity;
+        let mut entity = self.ir.return_expr.as_ref().unwrap().clone().entity;
         let mut property = self.ir.return_expr.as_ref().unwrap().clone().property;
         if property.chars().next().unwrap() == ".".chars().next().unwrap() {
             property.remove(0);
         }
 
         if entity == "trace" {
-            // TODO
+            entity = self.ir.root_id.clone();
+            self.make_storage_rpc_value_from_trace(self.ir.root_id.clone(), property);
         } else {
             let num_struct_filters = self.ir.struct_filters.len();
             if !self.ir.struct_filters[num_struct_filters - 1]
@@ -281,36 +355,34 @@ impl CodeGenSimulator {
             {
                 panic!("Unknown entity in return expression");
             }
-
-            let ret_block = format!(
-               "let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), \"{node_id}\".to_string());
-               if node_ptr.is_none() {{
-                   print!(\"WARNING Node {node_id} not found\");
-                   return vec!(x);
-               }}
-               let mut trace_node_index = None;
-               for map in m {{
-                   if self.target_graph.as_ref().unwrap().node_weight(map.0).unwrap().0 == \"{node_id}\" {{
-                       trace_node_index = Some(map.1);
-                       break;
-                   }}
-               }}
-               if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key(\"{prop}\") {{
-                   // we have not yet collected the return property or have a mapping error
-                   return vec!(x);
-               }}
-               let mut ret_{prop} = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ \"{prop}\" ];\n
-               value = ret_{prop}.to_string();\n",
-                   node_id = entity,
-                   prop = property
-                );
-
-            self.response_blocks.push(ret_block);
+            self.make_storage_rpc_value_from_target(entity, property);
         }
     }
 
     fn make_aggr_block(&mut self) {
-        // TODO
+        // for the simulator, aggregation is the same as return
+        if self.ir.aggregate.is_none() {
+            return;
+        }
+        let entity = self.ir.aggregate.as_ref().unwrap().clone().entity;
+        let mut property = self.ir.aggregate.as_ref().unwrap().clone().property;
+        if property.chars().next().unwrap() == ".".chars().next().unwrap() {
+            property.remove(0);
+        }
+
+        let node_id: String;
+        if entity == "trace" {
+            self.make_storage_rpc_value_from_trace(self.ir.root_id.clone(), property);
+        } else {
+            let num_struct_filters = self.ir.struct_filters.len();
+            if !self.ir.struct_filters[num_struct_filters - 1]
+                .vertices
+                .contains(&entity)
+            {
+                panic!("Unknown entity in return expression");
+            }
+            self.make_storage_rpc_value_from_target(entity, property);
+        }
     }
 }
 
@@ -349,7 +421,7 @@ mod tests {
         let token_source = CommonTokenStream::new(_lexer);
         let mut parser = CypherParser::new(token_source);
         let result = parser.oC_Cypher().expect("parsed unsuccessfully");
-        visit_result(result)
+        visit_result(result, "".to_string())
     }
 
     #[test]
@@ -358,5 +430,17 @@ mod tests {
             get_codegen_from_query("MATCH (a) -[]-> (b)-[]->(c) RETURN a.count".to_string());
         assert!(!result.struct_filters.is_empty());
         let codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());
+    }
+
+    #[test]
+    fn get_group_by() {
+        let result = get_codegen_from_query(
+            "MATCH (a {service_name: \"productpage-v1\"}) RETURN a.count, agg".to_string(),
+        );
+        assert!(!result.struct_filters.is_empty());
+        let _codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());
+        assert!(!_codegen.target_blocks.is_empty());
+        assert!(!_codegen.ir.struct_filters.is_empty());
+        assert!(!_codegen.ir.aggregate.is_none());
     }
 }

--- a/rewrite/ir.rs
+++ b/rewrite/ir.rs
@@ -59,10 +59,11 @@ impl IrReturn {
 #[derive(Clone, Debug, Serialize)]
 pub struct VisitorResults {
     pub struct_filters: Vec<StructuralFilter>,
-    pub prop_filters: Vec<AttributeFilter>,
+    pub attr_filters: Vec<AttributeFilter>,
     pub return_expr: Option<IrReturn>,
     pub aggregate: Option<Aggregate>,
     pub maps: Vec<String>,
+    pub root_id: String,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/rewrite/main.rs
+++ b/rewrite/main.rs
@@ -115,6 +115,7 @@ fn main() {
     let tf = CommonTokenFactory::default();
     // Read query from file specified by command line argument.
     let query_file = matches.value_of("query").unwrap();
+    let root_id = matches.value_of("root_node").unwrap();
     let query: String = fs::read_to_string(query_file).unwrap();
     let query_stream = InputStream::new_owned(query.into_boxed_str());
     let lexer = CypherLexer::new_with_token_factory(query_stream, &tf);
@@ -126,7 +127,7 @@ fn main() {
         log::error!("Error parsing query: {:?}", e);
         return;
     }
-    let visitor_results = dyntracing::to_ir::visit_result(result.unwrap());
+    let visitor_results = dyntracing::to_ir::visit_result(result.unwrap(), root_id.to_string());
     match matches.value_of("compilation_mode").unwrap() {
         "sim" => {
             // TODO: support multiple UDF files

--- a/rewrite/to_ir.rs
+++ b/rewrite/to_ir.rs
@@ -22,7 +22,7 @@ use std::rc::Rc;
 
 pub struct FilterVisitor {
     struct_filters: Vec<StructuralFilter>,
-    prop_filters: Vec<AttributeFilter>,
+    attr_filters: Vec<AttributeFilter>,
     return_items: Vec<IrReturn>,
 }
 
@@ -30,7 +30,7 @@ impl Default for FilterVisitor {
     fn default() -> Self {
         FilterVisitor {
             struct_filters: Vec::new(),
-            prop_filters: Vec::new(),
+            attr_filters: Vec::new(),
             return_items: Vec::new(),
         }
     }
@@ -105,7 +105,7 @@ impl<'i> CypherVisitor<'i> for FilterVisitor {
             property,
             value,
         };
-        self.prop_filters.push(attr_filter);
+        self.attr_filters.push(attr_filter);
     }
 
     fn visit_oC_PatternElement(&mut self, ctx: &OC_PatternElementContext<'i>) {
@@ -282,7 +282,7 @@ pub fn get_map_functions(mut results: VisitorResults) -> VisitorResults {
         }
     }
 
-    for attribute_filter in &results.prop_filters {
+    for attribute_filter in &results.attr_filters {
         if !known_properties.contains(&attribute_filter.property) {
             unknown_properties.insert(attribute_filter.property.to_string());
         }
@@ -306,17 +306,18 @@ pub fn get_map_functions(mut results: VisitorResults) -> VisitorResults {
 
 /// This is a function that aggregates all the functionality above;  it makes a visitor,
 /// visits everything in the query via accept, and then finds the map functions.
-pub fn visit_result(result: Rc<OC_CypherContextAll>) -> VisitorResults {
+pub fn visit_result(result: Rc<OC_CypherContextAll>, root_id: String) -> VisitorResults {
     let mut filter_visitor = FilterVisitor::default();
     let mut return_visitor = ReturnVisitor::default();
     let _res = result.accept(&mut filter_visitor);
     let _res = result.accept(&mut return_visitor);
     let results = VisitorResults {
         struct_filters: filter_visitor.struct_filters,
-        prop_filters: filter_visitor.prop_filters,
+        attr_filters: filter_visitor.attr_filters,
         return_expr: return_visitor.return_expr,
         aggregate: return_visitor.aggregate,
         maps: Vec::new(),
+        root_id: root_id,
     };
     get_map_functions(results)
 }
@@ -380,10 +381,10 @@ mod tests {
         let mut visitor = FilterVisitor::default();
         let _res = result.accept(&mut visitor);
         assert!(!visitor.struct_filters.is_empty());
-        assert!(!visitor.prop_filters.is_empty());
-        assert!(visitor.prop_filters[0].node == "trace".to_string());
-        assert!(visitor.prop_filters[0].property == ".latency".to_string());
-        assert!(visitor.prop_filters[0].value == "500".to_string());
+        assert!(!visitor.attr_filters.is_empty());
+        assert!(visitor.attr_filters[0].node == "trace".to_string());
+        assert!(visitor.attr_filters[0].property == ".latency".to_string());
+        assert!(visitor.attr_filters[0].value == "500".to_string());
     }
 
     #[test]
@@ -393,14 +394,14 @@ mod tests {
         let mut visitor = FilterVisitor::default();
         let _res = result.accept(&mut visitor);
         assert!(!visitor.struct_filters.is_empty());
-        assert!(visitor.prop_filters.len() == 2);
-        assert!(visitor.prop_filters[0].node == "trace".to_string());
-        assert!(visitor.prop_filters[0].property == ".latency".to_string());
-        assert!(visitor.prop_filters[0].value == "500".to_string());
+        assert!(visitor.attr_filters.len() == 2);
+        assert!(visitor.attr_filters[0].node == "trace".to_string());
+        assert!(visitor.attr_filters[0].property == ".latency".to_string());
+        assert!(visitor.attr_filters[0].value == "500".to_string());
 
-        assert!(visitor.prop_filters[1].node == "trace".to_string());
-        assert!(visitor.prop_filters[1].property == ".client".to_string());
-        assert!(visitor.prop_filters[1].value == "xyz".to_string());
+        assert!(visitor.attr_filters[1].node == "trace".to_string());
+        assert!(visitor.attr_filters[1].property == ".client".to_string());
+        assert!(visitor.attr_filters[1].value == "xyz".to_string());
     }
 
     #[test]
@@ -436,10 +437,11 @@ mod tests {
         let _res = result.accept(&mut return_visitor);
         let mut results = VisitorResults {
             struct_filters: filter_visitor.struct_filters,
-            prop_filters: filter_visitor.prop_filters,
+            attr_filters: filter_visitor.attr_filters,
             return_expr: return_visitor.return_expr,
             aggregate: return_visitor.aggregate,
             maps: Vec::new(),
+            root_id: "".to_string(),
         };
         results = get_map_functions(results);
         assert!(results.maps.len() == 2);

--- a/rewrite/to_ir.rs
+++ b/rewrite/to_ir.rs
@@ -317,7 +317,7 @@ pub fn visit_result(result: Rc<OC_CypherContextAll>, root_id: String) -> Visitor
         return_expr: return_visitor.return_expr,
         aggregate: return_visitor.aggregate,
         maps: Vec::new(),
-        root_id: root_id,
+        root_id,
     };
     get_map_functions(results)
 }

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -62,8 +62,9 @@ fn check_compilation_cc(
 #[test_case("get_service_name.cql", vec![]; "get_service_name")]
 #[test_case("height.cql", vec!["height.rs"]; "height")]
 #[test_case("histogram.cql", vec!["histogram.rs"]; "inconclusive - histogram")]
-#[test_case("request_size.cql", vec![]; "inconclusive - request_size")]
-#[test_case("request_size_avg.cql", vec![]; "inconclusive - request_size_avg")]
+#[test_case("request_size.cql", vec![]; "request_size")]
+#[test_case("request_size_avg.cql", vec![]; "request_size_avg")]
+#[test_case("request_size_avg_trace_attr.cql", vec![]; "request_size_avg_trace_attr")]
 #[test_case("latency.cql", vec!["latency.rs"]; "inconclusive - latency")]
 fn check_compilation_rust(
     query_name: &str,
@@ -94,7 +95,7 @@ fn check_compilation_rust(
     out_file.set_extension("rs");
     args.extend(vec!["-o", out_file.to_str().unwrap()]);
     args.extend(vec!["-c", "sim"]);
-    args.extend(vec!["--root-node", "0"]);
+    args.extend(vec!["--root-node", "productpage-v1"]);
     cmd.args(args);
     cmd.assert().success();
 


### PR DESCRIPTION
This implements group by;  there wasn't much to do for group, since in the simulator, one has to put in the aggregating function as an argument.  So in the filter itself, not much is different from return, hence why they share the same helper function.

I also implemented trace-level attributes, both for attribute filters, and for returns/group bys.  An example query using them is request_size_avg_trace_attr.cql.

There are also some other small edits, like standardizing the name for prop_filter vs attr_filter in to_ir.rs.