### PR TITLE
Baggage serialization

### DIFF
--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -10,11 +10,34 @@ extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct Property {
+    entity: String,
+    property_name: String,
+    value: String,
+}
 
+impl Property {
+    fn default() -> Property {
+        Property {
+            entity: String::new(),
+            property_name: String::new(),
+            value: String::new()
+        }
+    }
+
+    fn new(entity: String, property_name: String, value: String) -> Property {
+        Property {
+            entity,
+            property_name,
+            value
+        }
+    }
+}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FerriedData {
     trace_graph: Graph<(String, IndexMap<String, String>), String>,
-    unassigned_properties: Vec<(String, String, String)>, // entity property value
+    unassigned_properties: Vec<Property>, // entity property value
 }
 
 impl FerriedData {
@@ -30,10 +53,10 @@ impl FerriedData {
     // and associate them with those nodes
     fn assign_properties(&mut self) {
         let mut to_delete = Vec::new();
-        for property in &self.unassigned_properties {
-            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+        for property in &mut self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.entity.clone());
             if node.is_some() {
-                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.property_name.clone(), property.value.clone());
                 to_delete.push(property.clone());
             }
         }
@@ -48,7 +71,7 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
             hdr.insert("ferried_data".to_string(), stored_data_string);
         }
         Err(e) => {
-            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            log::error!("ERROR:  could not translate stored data to json string: {0}\n", e);
         }
     }
 }
@@ -104,7 +127,7 @@ impl Filter {
 
     pub fn set_whoami(&mut self) {
         if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
-            print!("WARNING: filter was initialized without envoy properties and thus cannot function");
+            log::warn!("filter was initialized without envoy properties and thus cannot function");
             return;
         }
         let my_node = self
@@ -116,7 +139,7 @@ impl Filter {
     pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
         // If you don't have data, nothing to store
         if !headers.contains_key("ferried_data") { 
-            print!("WARNING: no ferried data\n");
+            log::warn!("no ferried data\n");
             return;
         }
         let uid = uid_64.to_string();
@@ -131,11 +154,11 @@ impl Filter {
 
         match serde_json::from_str(&headers["ferried_data"]) {
             Ok(d) => { data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
         match serde_json::from_str(&self.envoy_shared_data[&uid]) {
             Ok(d) => { stored_data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
 
 
@@ -157,7 +180,7 @@ impl Filter {
                     stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
                 }
                 None => {
-                    print!("Error:  no edge endpoints found \n");
+                    log::error!("no edge endpoints found \n");
                     return;
                 }
             }
@@ -175,7 +198,7 @@ impl Filter {
                 self.envoy_shared_data.insert(uid, stored_data_string);
             }
             Err(e) => {
-                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                log::error!("could not translate stored data to json string: {0}\n", e);
             }
         }
 
@@ -212,7 +235,7 @@ impl Filter {
                     }
                 }
                 Err(e) => {
-                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                    log::error!("could not parse envoy shared data: {0}\n", e);
                 }
 
             }
@@ -246,7 +269,7 @@ impl Filter {
             match serde_json::from_str(&x.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
                 Err(e) => {
-                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    log::error!("could not translate stored data to json string: {0}\n", e);
                     return vec![x];
                 }
             }
@@ -254,10 +277,10 @@ impl Filter {
 
         // Insert properties to collect
         let mut prop_tuple;
-        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+        prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    "service_name".to_string(), 
                                                    self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
-                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    "service_name".to_string(), 
                                                    self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
                                              ferried_data.unassigned_properties.push(prop_tuple); 
@@ -284,7 +307,7 @@ impl Filter {
         } else {
             match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
-                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+                Err(e) => { log::error!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
             }
         }
 
@@ -305,7 +328,7 @@ impl Filter {
                 let mut value : String;
                 let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
         if node_ptr.is_none() {
-           print!("WARNING Node a not found");
+           log::warn!("Node a not found");
                 return vec![original_rpc];
         }
         let mut trace_node_index = None;

--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -2,11 +2,57 @@ use rpc_lib::rpc::Rpc;
 use indexmap::map::IndexMap;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
-use petgraph::Outgoing;
+use petgraph::Incoming;
 use graph_utils::utils;
 use graph_utils::iso::find_mapping_shamir_centralized;
+use serde::{Serialize, Deserialize};
+extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FerriedData {
+    trace_graph: Graph<(String, IndexMap<String, String>), String>,
+    unassigned_properties: Vec<(String, String, String)>, // entity property value
+}
+
+impl FerriedData {
+    fn default() -> FerriedData {
+        FerriedData {
+            trace_graph: Graph::new(),
+            unassigned_properties: Vec::new(),
+            
+        }
+    }
+
+    // take any unassigned properties that apply to nodes in the graph,
+    // and associate them with those nodes
+    fn assign_properties(&mut self) {
+        let mut to_delete = Vec::new();
+        for property in &self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+            if node.is_some() {
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                to_delete.push(property.clone());
+            }
+        }
+        self.unassigned_properties.retain(|x| !to_delete.contains(&x));
+
+    }
+}
+
+fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
+    match serde_json::to_string(fd) {
+        Ok(stored_data_string) => {
+            hdr.insert("ferried_data".to_string(), stored_data_string);
+        }
+        Err(e) => {
+            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+        }
+    }
+}
+
 
 // user defined functions:
 
@@ -19,33 +65,11 @@ pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 // an Option<String> for every possible envoy value
 
 #[derive(Clone, Debug)]
-pub struct State {
-    pub type_of_state: Option<String>,
-    pub string_data: Option<String>,
-}
-
-impl State {
-    pub fn new() -> State {
-        State {
-            type_of_state: None,
-            string_data: None,
-        }
-    }
-
-    pub fn new_with_str(str_data: String) -> State {
-        State {
-            type_of_state: Some(String::from("String")),
-            string_data: Some(str_data),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,
     pub target_graph: Option<Graph<(String, IndexMap<String, String>), String>>,
-    pub filter_state: IndexMap<String, State>,
-    pub envoy_shared_data: IndexMap<String, String>,
+    pub filter_state: IndexMap<String, String>,
+    pub envoy_shared_data: IndexMap<String, String>, // trace ID to stored ferried data as string 
     pub collected_properties: Vec<String>, //properties to collect
 }
 
@@ -63,14 +87,10 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
-        let mut hash = IndexMap::new();
-        for key in string_data.keys() {
-            hash.insert(key.clone(), State::new_with_str(string_data[key].clone()));
-        }
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,
-                                   filter_state: hash,
+                                   filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
                                    collected_properties: vec!("service_name".to_string(), "service_name".to_string(),  ),
                                }))
@@ -83,87 +103,123 @@ impl Filter {
     }
 
     pub fn set_whoami(&mut self) {
-        let my_node_wrapped = self
-            .filter_state
-            .get("node.metadata.WORKLOAD_NAME");
-        if my_node_wrapped.is_none() {
+        if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
             print!("WARNING: filter was initialized without envoy properties and thus cannot function");
             return;
         }
-        let my_node = my_node_wrapped
-            .unwrap()
-            .string_data
-            .clone()
-            .unwrap();
+        let my_node = self
+            .filter_state["node.metadata.WORKLOAD_NAME"].clone();
         self.whoami = Some(my_node);
         assert!(self.whoami.is_some());
     }
 
-    pub fn store_headers(&mut self, x: Rpc) {
-        // store path as well as properties
-        let prop_str = format!("{uid}_properties_path", uid=x.uid);
-        if x.headers.contains_key("properties_path") {
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(",");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(&x.headers["properties_path"]);
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(";");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(self.whoami.as_ref().unwrap());
-            }
-            else {
-                // add yourself
-                let mut cur_path = x.headers["properties_path"].clone();
-                cur_path.push_str(";");
-                cur_path.push_str(self.whoami.as_ref().unwrap());
-                self.envoy_shared_data.insert(prop_str, cur_path);
-            }
+    pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
+        // If you don't have data, nothing to store
+        if !headers.contains_key("ferried_data") { 
+            print!("WARNING: no ferried data\n");
+            return;
         }
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=x.uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if x.headers.contains_key(&prop_key) {
-                if self.envoy_shared_data.contains_key(&prop_str) { // concatenate with comma if not duplicate
-                    // make lists of properties
-                    let properties_unified = self.envoy_shared_data[&prop_str].clone();
-                    let mut properties : Vec<String> = properties_unified.split(",").map(|s| s.to_string()).collect();
-                    let cur_properties_unified = x.headers[&prop_key].clone();
-                    let mut cur_properties : Vec<String> = cur_properties_unified.split(",").map(|s| s.to_string()).collect();
+        let uid = uid_64.to_string();
+        // If there is no data stored, you needn't merge - just throw it in
+        if !self.envoy_shared_data.contains_key(&uid) {
+            self.envoy_shared_data.insert(uid.clone(), headers["ferried_data"].clone());
+        }
 
-                    // merge lists and remove duplicates
-                    properties.append(&mut cur_properties);
-                    properties.sort_unstable(); // must sort for dedup to work
-                    properties.dedup();
+        // Else, we merge in 2 parts, for each of the struct values
+        let mut data: FerriedData;
+        let mut stored_data: FerriedData;
 
-                    // store result
-                    let property_string_to_store = properties.join(",");
-                    self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store.clone());
-                } else {
-                    self.envoy_shared_data.insert(prop_str.clone(), x.headers[&prop_key].clone());
+        match serde_json::from_str(&headers["ferried_data"]) {
+            Ok(d) => { data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+        match serde_json::from_str(&self.envoy_shared_data[&uid]) {
+            Ok(d) => { stored_data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+
+
+        // 2. Merge the graphs by simply adding it - later, when we merge, we will
+        //    make a root
+
+        // add node
+        for node in data.trace_graph.node_indices() {
+            stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap().clone());
+        }
+        // add edges
+        for edge in data.trace_graph.edge_indices() {
+            match data.trace_graph.edge_endpoints(edge) {
+                Some((edge0, edge1)) => {
+                    let edge0_weight = &data.trace_graph.node_weight(edge0).unwrap().0;
+                    let edge1_weight = &data.trace_graph.node_weight(edge1).unwrap().0;
+                    let edge0_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge0_weight.to_string()).unwrap();
+                    let edge1_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge1_weight.to_string()).unwrap();
+                    stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
+                }
+                None => {
+                    print!("Error:  no edge endpoints found \n");
+                    return;
                 }
             }
         }
+
+        // 3. merge unassigned properties
+        //    these are properties we have collected but are not yet in the graph
+        stored_data.unassigned_properties.append(&mut data.unassigned_properties);
+        stored_data.unassigned_properties.sort_unstable();
+        stored_data.unassigned_properties.dedup();
+        stored_data.assign_properties();
+
+        match serde_json::to_string(&stored_data) {
+            Ok(stored_data_string) => {
+                self.envoy_shared_data.insert(uid, stored_data_string);
+            }
+            Err(e) => {
+                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            }
+        }
+
     }
 
     pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: IndexMap<String, String>) -> IndexMap<String, String> {
-        // if we are a response, we should do path bookkeeping
-        if new_rpc_headers["direction"] == "response" {
-            let prop_str = format!("{uid}_properties_path", uid=uid);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert("properties_path".to_string(), self.envoy_shared_data[&prop_str].clone());
-            }
-            else { new_rpc_headers.insert("properties_path".to_string(), self.whoami.as_ref().unwrap().clone()); }
-        }
+        let uid_str = uid.to_string();
+        let mut my_indexmap = IndexMap::new();
+        my_indexmap.insert("node.metadata.WORKLOAD_NAME".to_string(), self.whoami.as_ref().unwrap().clone());
 
-        // all other properties
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert(prop_key, self.envoy_shared_data[&prop_str].clone());
-            } else {
-                if new_rpc_headers["direction"] != "request" { 
-                    println!("WARNING: could not find value for {0}", prop_str); 
+        if self.envoy_shared_data.contains_key(&uid_str) {
+            match serde_json::from_str(&self.envoy_shared_data[&uid_str]) {
+                Ok(d) => {
+                    // 1. TODO:  if needed, do things to set S
+                    // 2. If response, add yourself as root
+                    if new_rpc_headers["direction"] == "response" {
+                        let mut data: FerriedData = d;
+                        let mut previous_roots = Vec::new();
+                        for node in data.trace_graph.node_indices() {
+                            if data.trace_graph.neighbors_directed(node, Incoming).count() == 0 {
+                                previous_roots.push(node);
+                            }
+                        }
+                        let me = data.trace_graph.add_node(
+                            (self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+    
+                        for previous_root in previous_roots {
+                            data.trace_graph.add_edge(me, previous_root, String::new());
+                        }
+                        data.assign_properties();
+
+                        // Finally, put all the data back in the headers
+                        put_ferried_data_in_hdrs(&mut data, &mut new_rpc_headers);
+                    }
                 }
+                Err(e) => {
+                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                }
+
             }
+        } else {
+            let mut new_ferried_data = FerriedData::default();
+            new_ferried_data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+            put_ferried_data_in_hdrs(&mut new_ferried_data, &mut new_rpc_headers);
         }
         return new_rpc_headers;
     }
@@ -181,83 +237,76 @@ impl Filter {
  
     }
 
-    pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, IndexMap<String, String>), String> {
-        let trace;
-        let mut path = mod_rpc.headers["properties_path"].clone();
-        let mut properties = Vec::new();
-        for header in mod_rpc.headers.keys() {
-            if header.contains("properties_") && header != "properties_path" {
-                properties.push(mod_rpc.headers[header].clone().replace("properties_", ""));
-            }
-        }
-        let prop_to_trace = properties.join(",");
-        trace = utils::generate_trace_graph_from_headers(path, prop_to_trace);
-        return trace;
-    }
-
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let mut prop_str;
-        prop_str = format!("{whoami}.{property}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="service_name",
-                                                      value=self.filter_state["node.metadata.WORKLOAD_NAME"].string_data.as_ref().unwrap().to_string());
-                                             
-        if x.headers.contains_key("properties_service_name") {
-            if !x.headers["properties_service_name"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(&prop_str);
+        // Fetch ferried data
+        let mut ferried_data: FerriedData;
+        if !x.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&x.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => {
+                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    return vec![x];
+                }
             }
         }
-        else {
-            x.headers.insert("properties_service_name".to_string(), prop_str);
-        }
-         prop_str = format!("{whoami}.{property}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="service_name",
-                                                      value=self.filter_state["node.metadata.WORKLOAD_NAME"].string_data.as_ref().unwrap().to_string());
-                                             
-        if x.headers.contains_key("properties_service_name") {
-            if !x.headers["properties_service_name"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(&prop_str);
-            }
-        }
-        else {
-            x.headers.insert("properties_service_name".to_string(), prop_str);
-        }
-         
-        self.store_headers(x.clone());
-        return vec!(x);
+
+        // Insert properties to collect
+        let mut prop_tuple;
+        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   "service_name".to_string(), 
+                                                   self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
+                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   "service_name".to_string(), 
+                                                   self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
+                                             ferried_data.unassigned_properties.push(prop_tuple); 
+
+        // Return ferried data to x, and store headers
+        put_ferried_data_in_hdrs(&mut ferried_data, &mut x.headers);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        // 0. Look up stored baggage, and merge it
         x.headers = self.merge_headers(x.uid, x.headers);
-
-        assert!(x.headers.contains_key("properties_path"));
 
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
-        let mut storage_rpc : Option<Rpc> = None;
-        let mut have_trace_level_attributes = true;
+        let mut storage_rpc : Rpc;
 
-        // calculate UDFs and store result, and check trace level properties
-        if self.whoami.as_ref().unwrap() == "productpage-v1" {
+        // 1. retrieve our ferried data, containing the newly merged
+        //    baggage
+        let mut ferried_data: FerriedData;
+        if !original_rpc.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+            }
+        }
+
+        // 2. calculate UDFs and store result, and check trace level properties
+        let root_id = "productpage-v1";
+            if self.whoami.as_ref().unwrap() == root_id {
          let mut trace_prop_str : String;
         } 
 
-        let mut trace_graph = self.create_trace_graph(x.clone());
-        let mapping = find_mapping_shamir_centralized(
-            &trace_graph,
-            self.target_graph.as_ref().unwrap(),
-        );
-        if mapping.is_some() {
-            let m = mapping.unwrap();
-            let mut value : String;
-            // TODO: do return stuff
-            let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
+        // 3. perform isomorphism and possibly return if root node
+        if self.whoami.as_ref().unwrap() == root_id {
+            let mapping = find_mapping_shamir_centralized(
+                &ferried_data.trace_graph,
+                self.target_graph.as_ref().unwrap(),
+            );
+            if mapping.is_some() {
+                let m = mapping.unwrap();
+                let mut value : String;
+                let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
         if node_ptr.is_none() {
            print!("WARNING Node a not found");
-                return vec!(x);
+                return vec![original_rpc];
         }
         let mut trace_node_index = None;
         for map in m {
@@ -266,37 +315,43 @@ impl Filter {
                 break;
             }
         }
-        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("service_name") {
+        if trace_node_index == None || !&ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("service_name") {
             // we have not yet collected the return property or have a mapping error
-            return vec!(x);
+            return vec![original_rpc];
         }
-        let mut ret_service_name = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "service_name" ];
+        let mut ret_service_name = &ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "service_name" ];
 
         value = ret_service_name.to_string();
  
-            let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
-            result_rpc
-                .headers
-                .insert("dest".to_string(), "storage".to_string());
-            result_rpc
-                .headers
-                .insert("direction".to_string(), "request".to_string());
-            result_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
-            storage_rpc = Some(result_rpc);
-            return vec!(x, storage_rpc.unwrap());
-       }
-       return vec!(x);
 
+                // Now you have the return value, so
+                // 3a. Make a storage rpc
+                storage_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
+                storage_rpc
+                    .headers
+                    .insert("dest".to_string(), "storage".to_string());
+                storage_rpc
+                    .headers
+                    .insert("direction".to_string(), "request".to_string());
+                storage_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
+
+                // 3b. Put baggage into regular rpc
+                put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+                return vec![original_rpc, storage_rpc];
+            }
+       }
+       put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+       return vec![original_rpc];
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
         x.headers = self.merge_headers(x.uid, x.headers);
-        return vec!(x);
+        return vec![x];
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        self.store_headers(x.clone());
-        return vec!(x);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
 

--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -81,12 +81,6 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
 
 
 
-// This represents a piece of state of the filter
-// it contains information that we get from calling getValue in the real filters
-// TODO:  since we no longer use these to define UDFs, we have no need for it
-// to be anything other than a string.  We should simplify it to simply have
-// an Option<String> for every possible envoy value
-
 #[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -102,12 +102,6 @@ fn mid_height(_graph: &Graph<(String, IndexMap<String, String>), String>, childr
 
 
 
-// This represents a piece of state of the filter
-// it contains information that we get from calling getValue in the real filters
-// TODO:  since we no longer use these to define UDFs, we have no need for it
-// to be anything other than a string.  We should simplify it to simply have
-// an Option<String> for every possible envoy value
-
 #[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -10,11 +10,34 @@ extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct Property {
+    entity: String,
+    property_name: String,
+    value: String,
+}
 
+impl Property {
+    fn default() -> Property {
+        Property {
+            entity: String::new(),
+            property_name: String::new(),
+            value: String::new()
+        }
+    }
+
+    fn new(entity: String, property_name: String, value: String) -> Property {
+        Property {
+            entity,
+            property_name,
+            value
+        }
+    }
+}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FerriedData {
     trace_graph: Graph<(String, IndexMap<String, String>), String>,
-    unassigned_properties: Vec<(String, String, String)>, // entity property value
+    unassigned_properties: Vec<Property>, // entity property value
 }
 
 impl FerriedData {
@@ -30,10 +53,10 @@ impl FerriedData {
     // and associate them with those nodes
     fn assign_properties(&mut self) {
         let mut to_delete = Vec::new();
-        for property in &self.unassigned_properties {
-            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+        for property in &mut self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.entity.clone());
             if node.is_some() {
-                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.property_name.clone(), property.value.clone());
                 to_delete.push(property.clone());
             }
         }
@@ -48,7 +71,7 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
             hdr.insert("ferried_data".to_string(), stored_data_string);
         }
         Err(e) => {
-            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            log::error!("ERROR:  could not translate stored data to json string: {0}\n", e);
         }
     }
 }
@@ -125,7 +148,7 @@ impl Filter {
 
     pub fn set_whoami(&mut self) {
         if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
-            print!("WARNING: filter was initialized without envoy properties and thus cannot function");
+            log::warn!("filter was initialized without envoy properties and thus cannot function");
             return;
         }
         let my_node = self
@@ -137,7 +160,7 @@ impl Filter {
     pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
         // If you don't have data, nothing to store
         if !headers.contains_key("ferried_data") { 
-            print!("WARNING: no ferried data\n");
+            log::warn!("no ferried data\n");
             return;
         }
         let uid = uid_64.to_string();
@@ -152,11 +175,11 @@ impl Filter {
 
         match serde_json::from_str(&headers["ferried_data"]) {
             Ok(d) => { data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
         match serde_json::from_str(&self.envoy_shared_data[&uid]) {
             Ok(d) => { stored_data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
 
 
@@ -178,7 +201,7 @@ impl Filter {
                     stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
                 }
                 None => {
-                    print!("Error:  no edge endpoints found \n");
+                    log::error!("no edge endpoints found \n");
                     return;
                 }
             }
@@ -196,7 +219,7 @@ impl Filter {
                 self.envoy_shared_data.insert(uid, stored_data_string);
             }
             Err(e) => {
-                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                log::error!("could not translate stored data to json string: {0}\n", e);
             }
         }
 
@@ -233,7 +256,7 @@ impl Filter {
                     }
                 }
                 Err(e) => {
-                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                    log::error!("could not parse envoy shared data: {0}\n", e);
                 }
 
             }
@@ -267,7 +290,7 @@ impl Filter {
             match serde_json::from_str(&x.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
                 Err(e) => {
-                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    log::error!("could not translate stored data to json string: {0}\n", e);
                     return vec![x];
                 }
             }
@@ -275,7 +298,7 @@ impl Filter {
 
         // Insert properties to collect
         let mut prop_tuple;
-        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+        prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    "service_name".to_string(), 
                                                    self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
                                              ferried_data.unassigned_properties.push(prop_tuple); 
@@ -302,7 +325,7 @@ impl Filter {
         } else {
             match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
-                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+                Err(e) => { log::error!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
             }
         }
 
@@ -345,7 +368,7 @@ impl Filter {
                 let mut value : String;
                 let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
         if node_ptr.is_none() {
-           print!("WARNING Node a not found");
+           log::warn!("Node a not found");
                 return vec![original_rpc];
         }
         let mut trace_node_index = None;

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -2,11 +2,57 @@ use rpc_lib::rpc::Rpc;
 use indexmap::map::IndexMap;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
-use petgraph::Outgoing;
+use petgraph::Incoming;
 use graph_utils::utils;
 use graph_utils::iso::find_mapping_shamir_centralized;
+use serde::{Serialize, Deserialize};
+extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FerriedData {
+    trace_graph: Graph<(String, IndexMap<String, String>), String>,
+    unassigned_properties: Vec<(String, String, String)>, // entity property value
+}
+
+impl FerriedData {
+    fn default() -> FerriedData {
+        FerriedData {
+            trace_graph: Graph::new(),
+            unassigned_properties: Vec::new(),
+            
+        }
+    }
+
+    // take any unassigned properties that apply to nodes in the graph,
+    // and associate them with those nodes
+    fn assign_properties(&mut self) {
+        let mut to_delete = Vec::new();
+        for property in &self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+            if node.is_some() {
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                to_delete.push(property.clone());
+            }
+        }
+        self.unassigned_properties.retain(|x| !to_delete.contains(&x));
+
+    }
+}
+
+fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
+    match serde_json::to_string(fd) {
+        Ok(stored_data_string) => {
+            hdr.insert("ferried_data".to_string(), stored_data_string);
+        }
+        Err(e) => {
+            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+        }
+    }
+}
+
 
 // user defined functions:
 // udf_type: Scalar
@@ -14,12 +60,12 @@ pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 // mid_func: mid_height
 // id: height
 
-fn leaf_height(_graph: Graph<(String, IndexMap<String, String>), String>) -> u32 {
+fn leaf_height(_graph: &Graph<(String, IndexMap<String, String>), String>) -> u32 {
     return 0;
 }
 
 // TODO:  must children's responses always be in string form?  can we generalize?
-fn mid_height(_graph: Graph<(String, IndexMap<String, String>), String>, children_responses: Vec<String>) -> u32 {
+fn mid_height(_graph: &Graph<(String, IndexMap<String, String>), String>, children_responses: Vec<String>) -> u32 {
     let mut max = 0;
     for response in children_responses {
         let response_as_u32 = response.parse::<u32>();
@@ -40,33 +86,11 @@ fn mid_height(_graph: Graph<(String, IndexMap<String, String>), String>, childre
 // an Option<String> for every possible envoy value
 
 #[derive(Clone, Debug)]
-pub struct State {
-    pub type_of_state: Option<String>,
-    pub string_data: Option<String>,
-}
-
-impl State {
-    pub fn new() -> State {
-        State {
-            type_of_state: None,
-            string_data: None,
-        }
-    }
-
-    pub fn new_with_str(str_data: String) -> State {
-        State {
-            type_of_state: Some(String::from("String")),
-            string_data: Some(str_data),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,
     pub target_graph: Option<Graph<(String, IndexMap<String, String>), String>>,
-    pub filter_state: IndexMap<String, State>,
-    pub envoy_shared_data: IndexMap<String, String>,
+    pub filter_state: IndexMap<String, String>,
+    pub envoy_shared_data: IndexMap<String, String>, // trace ID to stored ferried data as string 
     pub collected_properties: Vec<String>, //properties to collect
 }
 
@@ -84,14 +108,10 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
-        let mut hash = IndexMap::new();
-        for key in string_data.keys() {
-            hash.insert(key.clone(), State::new_with_str(string_data[key].clone()));
-        }
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,
-                                   filter_state: hash,
+                                   filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
                                    collected_properties: vec!("service_name".to_string(), "height".to_string(),  ),
                                }))
@@ -104,87 +124,123 @@ impl Filter {
     }
 
     pub fn set_whoami(&mut self) {
-        let my_node_wrapped = self
-            .filter_state
-            .get("node.metadata.WORKLOAD_NAME");
-        if my_node_wrapped.is_none() {
+        if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
             print!("WARNING: filter was initialized without envoy properties and thus cannot function");
             return;
         }
-        let my_node = my_node_wrapped
-            .unwrap()
-            .string_data
-            .clone()
-            .unwrap();
+        let my_node = self
+            .filter_state["node.metadata.WORKLOAD_NAME"].clone();
         self.whoami = Some(my_node);
         assert!(self.whoami.is_some());
     }
 
-    pub fn store_headers(&mut self, x: Rpc) {
-        // store path as well as properties
-        let prop_str = format!("{uid}_properties_path", uid=x.uid);
-        if x.headers.contains_key("properties_path") {
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(",");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(&x.headers["properties_path"]);
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(";");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(self.whoami.as_ref().unwrap());
-            }
-            else {
-                // add yourself
-                let mut cur_path = x.headers["properties_path"].clone();
-                cur_path.push_str(";");
-                cur_path.push_str(self.whoami.as_ref().unwrap());
-                self.envoy_shared_data.insert(prop_str, cur_path);
-            }
+    pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
+        // If you don't have data, nothing to store
+        if !headers.contains_key("ferried_data") { 
+            print!("WARNING: no ferried data\n");
+            return;
         }
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=x.uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if x.headers.contains_key(&prop_key) {
-                if self.envoy_shared_data.contains_key(&prop_str) { // concatenate with comma if not duplicate
-                    // make lists of properties
-                    let properties_unified = self.envoy_shared_data[&prop_str].clone();
-                    let mut properties : Vec<String> = properties_unified.split(",").map(|s| s.to_string()).collect();
-                    let cur_properties_unified = x.headers[&prop_key].clone();
-                    let mut cur_properties : Vec<String> = cur_properties_unified.split(",").map(|s| s.to_string()).collect();
+        let uid = uid_64.to_string();
+        // If there is no data stored, you needn't merge - just throw it in
+        if !self.envoy_shared_data.contains_key(&uid) {
+            self.envoy_shared_data.insert(uid.clone(), headers["ferried_data"].clone());
+        }
 
-                    // merge lists and remove duplicates
-                    properties.append(&mut cur_properties);
-                    properties.sort_unstable(); // must sort for dedup to work
-                    properties.dedup();
+        // Else, we merge in 2 parts, for each of the struct values
+        let mut data: FerriedData;
+        let mut stored_data: FerriedData;
 
-                    // store result
-                    let property_string_to_store = properties.join(",");
-                    self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store.clone());
-                } else {
-                    self.envoy_shared_data.insert(prop_str.clone(), x.headers[&prop_key].clone());
+        match serde_json::from_str(&headers["ferried_data"]) {
+            Ok(d) => { data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+        match serde_json::from_str(&self.envoy_shared_data[&uid]) {
+            Ok(d) => { stored_data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+
+
+        // 2. Merge the graphs by simply adding it - later, when we merge, we will
+        //    make a root
+
+        // add node
+        for node in data.trace_graph.node_indices() {
+            stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap().clone());
+        }
+        // add edges
+        for edge in data.trace_graph.edge_indices() {
+            match data.trace_graph.edge_endpoints(edge) {
+                Some((edge0, edge1)) => {
+                    let edge0_weight = &data.trace_graph.node_weight(edge0).unwrap().0;
+                    let edge1_weight = &data.trace_graph.node_weight(edge1).unwrap().0;
+                    let edge0_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge0_weight.to_string()).unwrap();
+                    let edge1_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge1_weight.to_string()).unwrap();
+                    stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
+                }
+                None => {
+                    print!("Error:  no edge endpoints found \n");
+                    return;
                 }
             }
         }
+
+        // 3. merge unassigned properties
+        //    these are properties we have collected but are not yet in the graph
+        stored_data.unassigned_properties.append(&mut data.unassigned_properties);
+        stored_data.unassigned_properties.sort_unstable();
+        stored_data.unassigned_properties.dedup();
+        stored_data.assign_properties();
+
+        match serde_json::to_string(&stored_data) {
+            Ok(stored_data_string) => {
+                self.envoy_shared_data.insert(uid, stored_data_string);
+            }
+            Err(e) => {
+                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            }
+        }
+
     }
 
     pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: IndexMap<String, String>) -> IndexMap<String, String> {
-        // if we are a response, we should do path bookkeeping
-        if new_rpc_headers["direction"] == "response" {
-            let prop_str = format!("{uid}_properties_path", uid=uid);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert("properties_path".to_string(), self.envoy_shared_data[&prop_str].clone());
-            }
-            else { new_rpc_headers.insert("properties_path".to_string(), self.whoami.as_ref().unwrap().clone()); }
-        }
+        let uid_str = uid.to_string();
+        let mut my_indexmap = IndexMap::new();
+        my_indexmap.insert("node.metadata.WORKLOAD_NAME".to_string(), self.whoami.as_ref().unwrap().clone());
 
-        // all other properties
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert(prop_key, self.envoy_shared_data[&prop_str].clone());
-            } else {
-                if new_rpc_headers["direction"] != "request" { 
-                    println!("WARNING: could not find value for {0}", prop_str); 
+        if self.envoy_shared_data.contains_key(&uid_str) {
+            match serde_json::from_str(&self.envoy_shared_data[&uid_str]) {
+                Ok(d) => {
+                    // 1. TODO:  if needed, do things to set S
+                    // 2. If response, add yourself as root
+                    if new_rpc_headers["direction"] == "response" {
+                        let mut data: FerriedData = d;
+                        let mut previous_roots = Vec::new();
+                        for node in data.trace_graph.node_indices() {
+                            if data.trace_graph.neighbors_directed(node, Incoming).count() == 0 {
+                                previous_roots.push(node);
+                            }
+                        }
+                        let me = data.trace_graph.add_node(
+                            (self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+    
+                        for previous_root in previous_roots {
+                            data.trace_graph.add_edge(me, previous_root, String::new());
+                        }
+                        data.assign_properties();
+
+                        // Finally, put all the data back in the headers
+                        put_ferried_data_in_hdrs(&mut data, &mut new_rpc_headers);
+                    }
                 }
+                Err(e) => {
+                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                }
+
             }
+        } else {
+            let mut new_ferried_data = FerriedData::default();
+            new_ferried_data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+            put_ferried_data_in_hdrs(&mut new_ferried_data, &mut new_rpc_headers);
         }
         return new_rpc_headers;
     }
@@ -202,105 +258,95 @@ impl Filter {
  
     }
 
-    pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, IndexMap<String, String>), String> {
-        let trace;
-        let mut path = mod_rpc.headers["properties_path"].clone();
-        let mut properties = Vec::new();
-        for header in mod_rpc.headers.keys() {
-            if header.contains("properties_") && header != "properties_path" {
-                properties.push(mod_rpc.headers[header].clone().replace("properties_", ""));
-            }
-        }
-        let prop_to_trace = properties.join(",");
-        trace = utils::generate_trace_graph_from_headers(path, prop_to_trace);
-        return trace;
-    }
-
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let mut prop_str;
-        prop_str = format!("{whoami}.{property}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="service_name",
-                                                      value=self.filter_state["node.metadata.WORKLOAD_NAME"].string_data.as_ref().unwrap().to_string());
-                                             
-        if x.headers.contains_key("properties_service_name") {
-            if !x.headers["properties_service_name"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(&prop_str);
+        // Fetch ferried data
+        let mut ferried_data: FerriedData;
+        if !x.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&x.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => {
+                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    return vec![x];
+                }
             }
         }
-        else {
-            x.headers.insert("properties_service_name".to_string(), prop_str);
-        }
-         
-        self.store_headers(x.clone());
-        return vec!(x);
+
+        // Insert properties to collect
+        let mut prop_tuple;
+        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   "service_name".to_string(), 
+                                                   self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
+                                             ferried_data.unassigned_properties.push(prop_tuple); 
+
+        // Return ferried data to x, and store headers
+        put_ferried_data_in_hdrs(&mut ferried_data, &mut x.headers);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        // 0. Look up stored baggage, and merge it
         x.headers = self.merge_headers(x.uid, x.headers);
-
-        assert!(x.headers.contains_key("properties_path"));
 
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
-        let mut storage_rpc : Option<Rpc> = None;
-        let mut have_trace_level_attributes = true;
+        let mut storage_rpc : Rpc;
 
-        // calculate UDFs and store result, and check trace level properties
+        // 1. retrieve our ferried data, containing the newly merged
+        //    baggage
+        let mut ferried_data: FerriedData;
+        if !original_rpc.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+            }
+        }
+
+        // 2. calculate UDFs and store result, and check trace level properties
         let my_height_value;
-    if x.headers.contains_key("properties_path") {
-            // TODO:  only create trace graph once and then add to it
-            let graph = self.create_trace_graph(x.clone());
-            let child_iterator = graph.neighbors_directed(
-                utils::get_node_with_id(&graph, self.whoami.as_ref().unwrap().clone()).unwrap(),
+            let child_iterator = ferried_data.trace_graph.neighbors_directed(
+                utils::get_node_with_id(&ferried_data.trace_graph, self.whoami.as_ref().unwrap().clone()).unwrap(),
                 petgraph::Outgoing);
             let mut child_values = Vec::new();
             for child in child_iterator {
-                child_values.push(graph.node_weight(child).unwrap().1["height"].clone());
+                child_values.push(ferried_data.trace_graph.node_weight(child).unwrap().1["height"].clone());
             }
             if child_values.len() == 0 {
-                my_height_value = leaf_height(graph);
+                my_height_value = leaf_height(&ferried_data.trace_graph).to_string();
             } else {
-                my_height_value = mid_height(graph, child_values);
+                my_height_value = mid_height(&ferried_data.trace_graph, child_values).to_string();
             }
-         }
-         else {
-             print!("WARNING: no path header");
-             return vec!(x);
-         }
 
-         let height_str = format!("{whoami}.{udf_id}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      udf_id="properties_height",
-                                                      value=my_height_value);
-        if x.headers.contains_key("properties_height") {
-            if !x.headers["properties_height"].contains(&height_str) { // don't add a udf property twice
-                x.headers.get_mut(&"properties_height".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_height".to_string()).unwrap().push_str(&height_str);
-            }
+         
+        let node = utils::get_node_with_id(&ferried_data.trace_graph, self.whoami.as_ref().unwrap().to_string()).unwrap();
+        // if we already have the property, don't add it
+        if !( ferried_data.trace_graph.node_weight(node).unwrap().1.contains_key("height") &&
+               ferried_data.trace_graph.node_weight(node).unwrap().1["height"] == my_height_value ) {
+           ferried_data.trace_graph.node_weight_mut(node).unwrap().1.insert(
+               "height".to_string(), my_height_value);
         }
-        else {
-            x.headers.insert("properties_height".to_string(), height_str);
-        }
-
-         if self.whoami.as_ref().unwrap() == "productpage-v1" {
+         let root_id = "productpage-v1";
+            if self.whoami.as_ref().unwrap() == root_id {
          let mut trace_prop_str : String;
         } 
 
-        let mut trace_graph = self.create_trace_graph(x.clone());
-        let mapping = find_mapping_shamir_centralized(
-            &trace_graph,
-            self.target_graph.as_ref().unwrap(),
-        );
-        if mapping.is_some() {
-            let m = mapping.unwrap();
-            let mut value : String;
-            // TODO: do return stuff
-            let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
+        // 3. perform isomorphism and possibly return if root node
+        if self.whoami.as_ref().unwrap() == root_id {
+            let mapping = find_mapping_shamir_centralized(
+                &ferried_data.trace_graph,
+                self.target_graph.as_ref().unwrap(),
+            );
+            if mapping.is_some() {
+                let m = mapping.unwrap();
+                let mut value : String;
+                let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
         if node_ptr.is_none() {
            print!("WARNING Node a not found");
-                return vec!(x);
+                return vec![original_rpc];
         }
         let mut trace_node_index = None;
         for map in m {
@@ -309,37 +355,43 @@ impl Filter {
                 break;
             }
         }
-        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("height") {
+        if trace_node_index == None || !&ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("height") {
             // we have not yet collected the return property or have a mapping error
-            return vec!(x);
+            return vec![original_rpc];
         }
-        let mut ret_height = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "height" ];
+        let mut ret_height = &ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "height" ];
 
         value = ret_height.to_string();
  
-            let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
-            result_rpc
-                .headers
-                .insert("dest".to_string(), "storage".to_string());
-            result_rpc
-                .headers
-                .insert("direction".to_string(), "request".to_string());
-            result_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
-            storage_rpc = Some(result_rpc);
-            return vec!(x, storage_rpc.unwrap());
-       }
-       return vec!(x);
 
+                // Now you have the return value, so
+                // 3a. Make a storage rpc
+                storage_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
+                storage_rpc
+                    .headers
+                    .insert("dest".to_string(), "storage".to_string());
+                storage_rpc
+                    .headers
+                    .insert("direction".to_string(), "request".to_string());
+                storage_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
+
+                // 3b. Put baggage into regular rpc
+                put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+                return vec![original_rpc, storage_rpc];
+            }
+       }
+       put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+       return vec![original_rpc];
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
         x.headers = self.merge_headers(x.uid, x.headers);
-        return vec!(x);
+        return vec![x];
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        self.store_headers(x.clone());
-        return vec!(x);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
 

--- a/example_queries/request_size.rs.ref
+++ b/example_queries/request_size.rs.ref
@@ -2,11 +2,57 @@ use rpc_lib::rpc::Rpc;
 use indexmap::map::IndexMap;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
-use petgraph::Outgoing;
+use petgraph::Incoming;
 use graph_utils::utils;
 use graph_utils::iso::find_mapping_shamir_centralized;
+use serde::{Serialize, Deserialize};
+extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FerriedData {
+    trace_graph: Graph<(String, IndexMap<String, String>), String>,
+    unassigned_properties: Vec<(String, String, String)>, // entity property value
+}
+
+impl FerriedData {
+    fn default() -> FerriedData {
+        FerriedData {
+            trace_graph: Graph::new(),
+            unassigned_properties: Vec::new(),
+            
+        }
+    }
+
+    // take any unassigned properties that apply to nodes in the graph,
+    // and associate them with those nodes
+    fn assign_properties(&mut self) {
+        let mut to_delete = Vec::new();
+        for property in &self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+            if node.is_some() {
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                to_delete.push(property.clone());
+            }
+        }
+        self.unassigned_properties.retain(|x| !to_delete.contains(&x));
+
+    }
+}
+
+fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
+    match serde_json::to_string(fd) {
+        Ok(stored_data_string) => {
+            hdr.insert("ferried_data".to_string(), stored_data_string);
+        }
+        Err(e) => {
+            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+        }
+    }
+}
+
 
 // user defined functions:
 
@@ -19,33 +65,11 @@ pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 // an Option<String> for every possible envoy value
 
 #[derive(Clone, Debug)]
-pub struct State {
-    pub type_of_state: Option<String>,
-    pub string_data: Option<String>,
-}
-
-impl State {
-    pub fn new() -> State {
-        State {
-            type_of_state: None,
-            string_data: None,
-        }
-    }
-
-    pub fn new_with_str(str_data: String) -> State {
-        State {
-            type_of_state: Some(String::from("String")),
-            string_data: Some(str_data),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,
     pub target_graph: Option<Graph<(String, IndexMap<String, String>), String>>,
-    pub filter_state: IndexMap<String, State>,
-    pub envoy_shared_data: IndexMap<String, String>,
+    pub filter_state: IndexMap<String, String>,
+    pub envoy_shared_data: IndexMap<String, String>, // trace ID to stored ferried data as string 
     pub collected_properties: Vec<String>, //properties to collect
 }
 
@@ -63,14 +87,10 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
-        let mut hash = IndexMap::new();
-        for key in string_data.keys() {
-            hash.insert(key.clone(), State::new_with_str(string_data[key].clone()));
-        }
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,
-                                   filter_state: hash,
+                                   filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
                                    collected_properties: vec!("service_name".to_string(), "request_size".to_string(),  ),
                                }))
@@ -83,87 +103,123 @@ impl Filter {
     }
 
     pub fn set_whoami(&mut self) {
-        let my_node_wrapped = self
-            .filter_state
-            .get("node.metadata.WORKLOAD_NAME");
-        if my_node_wrapped.is_none() {
+        if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
             print!("WARNING: filter was initialized without envoy properties and thus cannot function");
             return;
         }
-        let my_node = my_node_wrapped
-            .unwrap()
-            .string_data
-            .clone()
-            .unwrap();
+        let my_node = self
+            .filter_state["node.metadata.WORKLOAD_NAME"].clone();
         self.whoami = Some(my_node);
         assert!(self.whoami.is_some());
     }
 
-    pub fn store_headers(&mut self, x: Rpc) {
-        // store path as well as properties
-        let prop_str = format!("{uid}_properties_path", uid=x.uid);
-        if x.headers.contains_key("properties_path") {
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(",");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(&x.headers["properties_path"]);
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(";");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(self.whoami.as_ref().unwrap());
-            }
-            else {
-                // add yourself
-                let mut cur_path = x.headers["properties_path"].clone();
-                cur_path.push_str(";");
-                cur_path.push_str(self.whoami.as_ref().unwrap());
-                self.envoy_shared_data.insert(prop_str, cur_path);
-            }
+    pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
+        // If you don't have data, nothing to store
+        if !headers.contains_key("ferried_data") { 
+            print!("WARNING: no ferried data\n");
+            return;
         }
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=x.uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if x.headers.contains_key(&prop_key) {
-                if self.envoy_shared_data.contains_key(&prop_str) { // concatenate with comma if not duplicate
-                    // make lists of properties
-                    let properties_unified = self.envoy_shared_data[&prop_str].clone();
-                    let mut properties : Vec<String> = properties_unified.split(",").map(|s| s.to_string()).collect();
-                    let cur_properties_unified = x.headers[&prop_key].clone();
-                    let mut cur_properties : Vec<String> = cur_properties_unified.split(",").map(|s| s.to_string()).collect();
+        let uid = uid_64.to_string();
+        // If there is no data stored, you needn't merge - just throw it in
+        if !self.envoy_shared_data.contains_key(&uid) {
+            self.envoy_shared_data.insert(uid.clone(), headers["ferried_data"].clone());
+        }
 
-                    // merge lists and remove duplicates
-                    properties.append(&mut cur_properties);
-                    properties.sort_unstable(); // must sort for dedup to work
-                    properties.dedup();
+        // Else, we merge in 2 parts, for each of the struct values
+        let mut data: FerriedData;
+        let mut stored_data: FerriedData;
 
-                    // store result
-                    let property_string_to_store = properties.join(",");
-                    self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store.clone());
-                } else {
-                    self.envoy_shared_data.insert(prop_str.clone(), x.headers[&prop_key].clone());
+        match serde_json::from_str(&headers["ferried_data"]) {
+            Ok(d) => { data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+        match serde_json::from_str(&self.envoy_shared_data[&uid]) {
+            Ok(d) => { stored_data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+
+
+        // 2. Merge the graphs by simply adding it - later, when we merge, we will
+        //    make a root
+
+        // add node
+        for node in data.trace_graph.node_indices() {
+            stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap().clone());
+        }
+        // add edges
+        for edge in data.trace_graph.edge_indices() {
+            match data.trace_graph.edge_endpoints(edge) {
+                Some((edge0, edge1)) => {
+                    let edge0_weight = &data.trace_graph.node_weight(edge0).unwrap().0;
+                    let edge1_weight = &data.trace_graph.node_weight(edge1).unwrap().0;
+                    let edge0_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge0_weight.to_string()).unwrap();
+                    let edge1_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge1_weight.to_string()).unwrap();
+                    stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
+                }
+                None => {
+                    print!("Error:  no edge endpoints found \n");
+                    return;
                 }
             }
         }
+
+        // 3. merge unassigned properties
+        //    these are properties we have collected but are not yet in the graph
+        stored_data.unassigned_properties.append(&mut data.unassigned_properties);
+        stored_data.unassigned_properties.sort_unstable();
+        stored_data.unassigned_properties.dedup();
+        stored_data.assign_properties();
+
+        match serde_json::to_string(&stored_data) {
+            Ok(stored_data_string) => {
+                self.envoy_shared_data.insert(uid, stored_data_string);
+            }
+            Err(e) => {
+                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            }
+        }
+
     }
 
     pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: IndexMap<String, String>) -> IndexMap<String, String> {
-        // if we are a response, we should do path bookkeeping
-        if new_rpc_headers["direction"] == "response" {
-            let prop_str = format!("{uid}_properties_path", uid=uid);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert("properties_path".to_string(), self.envoy_shared_data[&prop_str].clone());
-            }
-            else { new_rpc_headers.insert("properties_path".to_string(), self.whoami.as_ref().unwrap().clone()); }
-        }
+        let uid_str = uid.to_string();
+        let mut my_indexmap = IndexMap::new();
+        my_indexmap.insert("node.metadata.WORKLOAD_NAME".to_string(), self.whoami.as_ref().unwrap().clone());
 
-        // all other properties
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert(prop_key, self.envoy_shared_data[&prop_str].clone());
-            } else {
-                if new_rpc_headers["direction"] != "request" { 
-                    println!("WARNING: could not find value for {0}", prop_str); 
+        if self.envoy_shared_data.contains_key(&uid_str) {
+            match serde_json::from_str(&self.envoy_shared_data[&uid_str]) {
+                Ok(d) => {
+                    // 1. TODO:  if needed, do things to set S
+                    // 2. If response, add yourself as root
+                    if new_rpc_headers["direction"] == "response" {
+                        let mut data: FerriedData = d;
+                        let mut previous_roots = Vec::new();
+                        for node in data.trace_graph.node_indices() {
+                            if data.trace_graph.neighbors_directed(node, Incoming).count() == 0 {
+                                previous_roots.push(node);
+                            }
+                        }
+                        let me = data.trace_graph.add_node(
+                            (self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+    
+                        for previous_root in previous_roots {
+                            data.trace_graph.add_edge(me, previous_root, String::new());
+                        }
+                        data.assign_properties();
+
+                        // Finally, put all the data back in the headers
+                        put_ferried_data_in_hdrs(&mut data, &mut new_rpc_headers);
+                    }
                 }
+                Err(e) => {
+                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                }
+
             }
+        } else {
+            let mut new_ferried_data = FerriedData::default();
+            new_ferried_data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+            put_ferried_data_in_hdrs(&mut new_ferried_data, &mut new_rpc_headers);
         }
         return new_rpc_headers;
     }
@@ -181,83 +237,76 @@ impl Filter {
  
     }
 
-    pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, IndexMap<String, String>), String> {
-        let trace;
-        let mut path = mod_rpc.headers["properties_path"].clone();
-        let mut properties = Vec::new();
-        for header in mod_rpc.headers.keys() {
-            if header.contains("properties_") && header != "properties_path" {
-                properties.push(mod_rpc.headers[header].clone().replace("properties_", ""));
-            }
-        }
-        let prop_to_trace = properties.join(",");
-        trace = utils::generate_trace_graph_from_headers(path, prop_to_trace);
-        return trace;
-    }
-
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let mut prop_str;
-        prop_str = format!("{whoami}.{property}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="service_name",
-                                                      value=self.filter_state["node.metadata.WORKLOAD_NAME"].string_data.as_ref().unwrap().to_string());
-                                             
-        if x.headers.contains_key("properties_service_name") {
-            if !x.headers["properties_service_name"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(&prop_str);
+        // Fetch ferried data
+        let mut ferried_data: FerriedData;
+        if !x.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&x.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => {
+                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    return vec![x];
+                }
             }
         }
-        else {
-            x.headers.insert("properties_service_name".to_string(), prop_str);
-        }
-         prop_str = format!("{whoami}.{property}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="request_size",
-                                                      value=self.filter_state["request.total_size"].string_data.as_ref().unwrap().to_string());
-                                             
-        if x.headers.contains_key("properties_request_size") {
-            if !x.headers["properties_request_size"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(&prop_str);
-            }
-        }
-        else {
-            x.headers.insert("properties_request_size".to_string(), prop_str);
-        }
-         
-        self.store_headers(x.clone());
-        return vec!(x);
+
+        // Insert properties to collect
+        let mut prop_tuple;
+        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   "service_name".to_string(), 
+                                                   self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
+                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   "request_size".to_string(), 
+                                                   self.filter_state["request.total_size"].clone());
+                                             ferried_data.unassigned_properties.push(prop_tuple); 
+
+        // Return ferried data to x, and store headers
+        put_ferried_data_in_hdrs(&mut ferried_data, &mut x.headers);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        // 0. Look up stored baggage, and merge it
         x.headers = self.merge_headers(x.uid, x.headers);
-
-        assert!(x.headers.contains_key("properties_path"));
 
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
-        let mut storage_rpc : Option<Rpc> = None;
-        let mut have_trace_level_attributes = true;
+        let mut storage_rpc : Rpc;
 
-        // calculate UDFs and store result, and check trace level properties
-        if self.whoami.as_ref().unwrap() == "productpage-v1" {
+        // 1. retrieve our ferried data, containing the newly merged
+        //    baggage
+        let mut ferried_data: FerriedData;
+        if !original_rpc.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+            }
+        }
+
+        // 2. calculate UDFs and store result, and check trace level properties
+        let root_id = "productpage-v1";
+            if self.whoami.as_ref().unwrap() == root_id {
          let mut trace_prop_str : String;
         } 
 
-        let mut trace_graph = self.create_trace_graph(x.clone());
-        let mapping = find_mapping_shamir_centralized(
-            &trace_graph,
-            self.target_graph.as_ref().unwrap(),
-        );
-        if mapping.is_some() {
-            let m = mapping.unwrap();
-            let mut value : String;
-            // TODO: do return stuff
-            let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
+        // 3. perform isomorphism and possibly return if root node
+        if self.whoami.as_ref().unwrap() == root_id {
+            let mapping = find_mapping_shamir_centralized(
+                &ferried_data.trace_graph,
+                self.target_graph.as_ref().unwrap(),
+            );
+            if mapping.is_some() {
+                let m = mapping.unwrap();
+                let mut value : String;
+                let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
         if node_ptr.is_none() {
            print!("WARNING Node a not found");
-                return vec!(x);
+                return vec![original_rpc];
         }
         let mut trace_node_index = None;
         for map in m {
@@ -266,37 +315,43 @@ impl Filter {
                 break;
             }
         }
-        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request_size") {
+        if trace_node_index == None || !&ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request_size") {
             // we have not yet collected the return property or have a mapping error
-            return vec!(x);
+            return vec![original_rpc];
         }
-        let mut ret_request_size = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
+        let mut ret_request_size = &ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
 
         value = ret_request_size.to_string();
  
-            let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
-            result_rpc
-                .headers
-                .insert("dest".to_string(), "storage".to_string());
-            result_rpc
-                .headers
-                .insert("direction".to_string(), "request".to_string());
-            result_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
-            storage_rpc = Some(result_rpc);
-            return vec!(x, storage_rpc.unwrap());
-       }
-       return vec!(x);
 
+                // Now you have the return value, so
+                // 3a. Make a storage rpc
+                storage_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
+                storage_rpc
+                    .headers
+                    .insert("dest".to_string(), "storage".to_string());
+                storage_rpc
+                    .headers
+                    .insert("direction".to_string(), "request".to_string());
+                storage_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
+
+                // 3b. Put baggage into regular rpc
+                put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+                return vec![original_rpc, storage_rpc];
+            }
+       }
+       put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+       return vec![original_rpc];
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
         x.headers = self.merge_headers(x.uid, x.headers);
-        return vec!(x);
+        return vec![x];
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        self.store_headers(x.clone());
-        return vec!(x);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
 

--- a/example_queries/request_size.rs.ref
+++ b/example_queries/request_size.rs.ref
@@ -10,11 +10,34 @@ extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct Property {
+    entity: String,
+    property_name: String,
+    value: String,
+}
 
+impl Property {
+    fn default() -> Property {
+        Property {
+            entity: String::new(),
+            property_name: String::new(),
+            value: String::new()
+        }
+    }
+
+    fn new(entity: String, property_name: String, value: String) -> Property {
+        Property {
+            entity,
+            property_name,
+            value
+        }
+    }
+}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FerriedData {
     trace_graph: Graph<(String, IndexMap<String, String>), String>,
-    unassigned_properties: Vec<(String, String, String)>, // entity property value
+    unassigned_properties: Vec<Property>, // entity property value
 }
 
 impl FerriedData {
@@ -30,10 +53,10 @@ impl FerriedData {
     // and associate them with those nodes
     fn assign_properties(&mut self) {
         let mut to_delete = Vec::new();
-        for property in &self.unassigned_properties {
-            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+        for property in &mut self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.entity.clone());
             if node.is_some() {
-                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.property_name.clone(), property.value.clone());
                 to_delete.push(property.clone());
             }
         }
@@ -48,7 +71,7 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
             hdr.insert("ferried_data".to_string(), stored_data_string);
         }
         Err(e) => {
-            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            log::error!("ERROR:  could not translate stored data to json string: {0}\n", e);
         }
     }
 }
@@ -104,7 +127,7 @@ impl Filter {
 
     pub fn set_whoami(&mut self) {
         if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
-            print!("WARNING: filter was initialized without envoy properties and thus cannot function");
+            log::warn!("filter was initialized without envoy properties and thus cannot function");
             return;
         }
         let my_node = self
@@ -116,7 +139,7 @@ impl Filter {
     pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
         // If you don't have data, nothing to store
         if !headers.contains_key("ferried_data") { 
-            print!("WARNING: no ferried data\n");
+            log::warn!("no ferried data\n");
             return;
         }
         let uid = uid_64.to_string();
@@ -131,11 +154,11 @@ impl Filter {
 
         match serde_json::from_str(&headers["ferried_data"]) {
             Ok(d) => { data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
         match serde_json::from_str(&self.envoy_shared_data[&uid]) {
             Ok(d) => { stored_data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
 
 
@@ -157,7 +180,7 @@ impl Filter {
                     stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
                 }
                 None => {
-                    print!("Error:  no edge endpoints found \n");
+                    log::error!("no edge endpoints found \n");
                     return;
                 }
             }
@@ -175,7 +198,7 @@ impl Filter {
                 self.envoy_shared_data.insert(uid, stored_data_string);
             }
             Err(e) => {
-                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                log::error!("could not translate stored data to json string: {0}\n", e);
             }
         }
 
@@ -212,7 +235,7 @@ impl Filter {
                     }
                 }
                 Err(e) => {
-                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                    log::error!("could not parse envoy shared data: {0}\n", e);
                 }
 
             }
@@ -246,7 +269,7 @@ impl Filter {
             match serde_json::from_str(&x.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
                 Err(e) => {
-                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    log::error!("could not translate stored data to json string: {0}\n", e);
                     return vec![x];
                 }
             }
@@ -254,10 +277,10 @@ impl Filter {
 
         // Insert properties to collect
         let mut prop_tuple;
-        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+        prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    "service_name".to_string(), 
                                                    self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
-                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    "request_size".to_string(), 
                                                    self.filter_state["request.total_size"].clone());
                                              ferried_data.unassigned_properties.push(prop_tuple); 
@@ -284,7 +307,7 @@ impl Filter {
         } else {
             match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
-                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+                Err(e) => { log::error!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
             }
         }
 
@@ -305,7 +328,7 @@ impl Filter {
                 let mut value : String;
                 let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
         if node_ptr.is_none() {
-           print!("WARNING Node a not found");
+           log::warn!("Node a not found");
                 return vec![original_rpc];
         }
         let mut trace_node_index = None;

--- a/example_queries/request_size.rs.ref
+++ b/example_queries/request_size.rs.ref
@@ -81,12 +81,6 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
 
 
 
-// This represents a piece of state of the filter
-// it contains information that we get from calling getValue in the real filters
-// TODO:  since we no longer use these to define UDFs, we have no need for it
-// to be anything other than a string.  We should simplify it to simply have
-// an Option<String> for every possible envoy value
-
 #[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,

--- a/example_queries/request_size_avg.rs.ref
+++ b/example_queries/request_size_avg.rs.ref
@@ -2,11 +2,57 @@ use rpc_lib::rpc::Rpc;
 use indexmap::map::IndexMap;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
-use petgraph::Outgoing;
+use petgraph::Incoming;
 use graph_utils::utils;
 use graph_utils::iso::find_mapping_shamir_centralized;
+use serde::{Serialize, Deserialize};
+extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FerriedData {
+    trace_graph: Graph<(String, IndexMap<String, String>), String>,
+    unassigned_properties: Vec<(String, String, String)>, // entity property value
+}
+
+impl FerriedData {
+    fn default() -> FerriedData {
+        FerriedData {
+            trace_graph: Graph::new(),
+            unassigned_properties: Vec::new(),
+            
+        }
+    }
+
+    // take any unassigned properties that apply to nodes in the graph,
+    // and associate them with those nodes
+    fn assign_properties(&mut self) {
+        let mut to_delete = Vec::new();
+        for property in &self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+            if node.is_some() {
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                to_delete.push(property.clone());
+            }
+        }
+        self.unassigned_properties.retain(|x| !to_delete.contains(&x));
+
+    }
+}
+
+fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
+    match serde_json::to_string(fd) {
+        Ok(stored_data_string) => {
+            hdr.insert("ferried_data".to_string(), stored_data_string);
+        }
+        Err(e) => {
+            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+        }
+    }
+}
+
 
 // user defined functions:
 
@@ -19,33 +65,11 @@ pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 // an Option<String> for every possible envoy value
 
 #[derive(Clone, Debug)]
-pub struct State {
-    pub type_of_state: Option<String>,
-    pub string_data: Option<String>,
-}
-
-impl State {
-    pub fn new() -> State {
-        State {
-            type_of_state: None,
-            string_data: None,
-        }
-    }
-
-    pub fn new_with_str(str_data: String) -> State {
-        State {
-            type_of_state: Some(String::from("String")),
-            string_data: Some(str_data),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,
     pub target_graph: Option<Graph<(String, IndexMap<String, String>), String>>,
-    pub filter_state: IndexMap<String, State>,
-    pub envoy_shared_data: IndexMap<String, String>,
+    pub filter_state: IndexMap<String, String>,
+    pub envoy_shared_data: IndexMap<String, String>, // trace ID to stored ferried data as string 
     pub collected_properties: Vec<String>, //properties to collect
 }
 
@@ -63,14 +87,10 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
-        let mut hash = IndexMap::new();
-        for key in string_data.keys() {
-            hash.insert(key.clone(), State::new_with_str(string_data[key].clone()));
-        }
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,
-                                   filter_state: hash,
+                                   filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
                                    collected_properties: vec!("service_name".to_string(), "request_size".to_string(),  ),
                                }))
@@ -83,87 +103,123 @@ impl Filter {
     }
 
     pub fn set_whoami(&mut self) {
-        let my_node_wrapped = self
-            .filter_state
-            .get("node.metadata.WORKLOAD_NAME");
-        if my_node_wrapped.is_none() {
+        if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
             print!("WARNING: filter was initialized without envoy properties and thus cannot function");
             return;
         }
-        let my_node = my_node_wrapped
-            .unwrap()
-            .string_data
-            .clone()
-            .unwrap();
+        let my_node = self
+            .filter_state["node.metadata.WORKLOAD_NAME"].clone();
         self.whoami = Some(my_node);
         assert!(self.whoami.is_some());
     }
 
-    pub fn store_headers(&mut self, x: Rpc) {
-        // store path as well as properties
-        let prop_str = format!("{uid}_properties_path", uid=x.uid);
-        if x.headers.contains_key("properties_path") {
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(",");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(&x.headers["properties_path"]);
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(";");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(self.whoami.as_ref().unwrap());
-            }
-            else {
-                // add yourself
-                let mut cur_path = x.headers["properties_path"].clone();
-                cur_path.push_str(";");
-                cur_path.push_str(self.whoami.as_ref().unwrap());
-                self.envoy_shared_data.insert(prop_str, cur_path);
-            }
+    pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
+        // If you don't have data, nothing to store
+        if !headers.contains_key("ferried_data") { 
+            print!("WARNING: no ferried data\n");
+            return;
         }
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=x.uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if x.headers.contains_key(&prop_key) {
-                if self.envoy_shared_data.contains_key(&prop_str) { // concatenate with comma if not duplicate
-                    // make lists of properties
-                    let properties_unified = self.envoy_shared_data[&prop_str].clone();
-                    let mut properties : Vec<String> = properties_unified.split(",").map(|s| s.to_string()).collect();
-                    let cur_properties_unified = x.headers[&prop_key].clone();
-                    let mut cur_properties : Vec<String> = cur_properties_unified.split(",").map(|s| s.to_string()).collect();
+        let uid = uid_64.to_string();
+        // If there is no data stored, you needn't merge - just throw it in
+        if !self.envoy_shared_data.contains_key(&uid) {
+            self.envoy_shared_data.insert(uid.clone(), headers["ferried_data"].clone());
+        }
 
-                    // merge lists and remove duplicates
-                    properties.append(&mut cur_properties);
-                    properties.sort_unstable(); // must sort for dedup to work
-                    properties.dedup();
+        // Else, we merge in 2 parts, for each of the struct values
+        let mut data: FerriedData;
+        let mut stored_data: FerriedData;
 
-                    // store result
-                    let property_string_to_store = properties.join(",");
-                    self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store.clone());
-                } else {
-                    self.envoy_shared_data.insert(prop_str.clone(), x.headers[&prop_key].clone());
+        match serde_json::from_str(&headers["ferried_data"]) {
+            Ok(d) => { data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+        match serde_json::from_str(&self.envoy_shared_data[&uid]) {
+            Ok(d) => { stored_data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+
+
+        // 2. Merge the graphs by simply adding it - later, when we merge, we will
+        //    make a root
+
+        // add node
+        for node in data.trace_graph.node_indices() {
+            stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap().clone());
+        }
+        // add edges
+        for edge in data.trace_graph.edge_indices() {
+            match data.trace_graph.edge_endpoints(edge) {
+                Some((edge0, edge1)) => {
+                    let edge0_weight = &data.trace_graph.node_weight(edge0).unwrap().0;
+                    let edge1_weight = &data.trace_graph.node_weight(edge1).unwrap().0;
+                    let edge0_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge0_weight.to_string()).unwrap();
+                    let edge1_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge1_weight.to_string()).unwrap();
+                    stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
+                }
+                None => {
+                    print!("Error:  no edge endpoints found \n");
+                    return;
                 }
             }
         }
+
+        // 3. merge unassigned properties
+        //    these are properties we have collected but are not yet in the graph
+        stored_data.unassigned_properties.append(&mut data.unassigned_properties);
+        stored_data.unassigned_properties.sort_unstable();
+        stored_data.unassigned_properties.dedup();
+        stored_data.assign_properties();
+
+        match serde_json::to_string(&stored_data) {
+            Ok(stored_data_string) => {
+                self.envoy_shared_data.insert(uid, stored_data_string);
+            }
+            Err(e) => {
+                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            }
+        }
+
     }
 
     pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: IndexMap<String, String>) -> IndexMap<String, String> {
-        // if we are a response, we should do path bookkeeping
-        if new_rpc_headers["direction"] == "response" {
-            let prop_str = format!("{uid}_properties_path", uid=uid);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert("properties_path".to_string(), self.envoy_shared_data[&prop_str].clone());
-            }
-            else { new_rpc_headers.insert("properties_path".to_string(), self.whoami.as_ref().unwrap().clone()); }
-        }
+        let uid_str = uid.to_string();
+        let mut my_indexmap = IndexMap::new();
+        my_indexmap.insert("node.metadata.WORKLOAD_NAME".to_string(), self.whoami.as_ref().unwrap().clone());
 
-        // all other properties
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert(prop_key, self.envoy_shared_data[&prop_str].clone());
-            } else {
-                if new_rpc_headers["direction"] != "request" { 
-                    println!("WARNING: could not find value for {0}", prop_str); 
+        if self.envoy_shared_data.contains_key(&uid_str) {
+            match serde_json::from_str(&self.envoy_shared_data[&uid_str]) {
+                Ok(d) => {
+                    // 1. TODO:  if needed, do things to set S
+                    // 2. If response, add yourself as root
+                    if new_rpc_headers["direction"] == "response" {
+                        let mut data: FerriedData = d;
+                        let mut previous_roots = Vec::new();
+                        for node in data.trace_graph.node_indices() {
+                            if data.trace_graph.neighbors_directed(node, Incoming).count() == 0 {
+                                previous_roots.push(node);
+                            }
+                        }
+                        let me = data.trace_graph.add_node(
+                            (self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+    
+                        for previous_root in previous_roots {
+                            data.trace_graph.add_edge(me, previous_root, String::new());
+                        }
+                        data.assign_properties();
+
+                        // Finally, put all the data back in the headers
+                        put_ferried_data_in_hdrs(&mut data, &mut new_rpc_headers);
+                    }
                 }
+                Err(e) => {
+                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                }
+
             }
+        } else {
+            let mut new_ferried_data = FerriedData::default();
+            new_ferried_data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+            put_ferried_data_in_hdrs(&mut new_ferried_data, &mut new_rpc_headers);
         }
         return new_rpc_headers;
     }
@@ -181,88 +237,94 @@ impl Filter {
  
     }
 
-    pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, IndexMap<String, String>), String> {
-        let trace;
-        let mut path = mod_rpc.headers["properties_path"].clone();
-        let mut properties = Vec::new();
-        for header in mod_rpc.headers.keys() {
-            if header.contains("properties_") && header != "properties_path" {
-                properties.push(mod_rpc.headers[header].clone().replace("properties_", ""));
-            }
-        }
-        let prop_to_trace = properties.join(",");
-        trace = utils::generate_trace_graph_from_headers(path, prop_to_trace);
-        return trace;
-    }
-
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let mut prop_str;
-        prop_str = format!("{whoami}.{property}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="service_name",
-                                                      value=self.filter_state["node.metadata.WORKLOAD_NAME"].string_data.as_ref().unwrap().to_string());
-                                             
-        if x.headers.contains_key("properties_service_name") {
-            if !x.headers["properties_service_name"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(&prop_str);
+        // Fetch ferried data
+        let mut ferried_data: FerriedData;
+        if !x.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&x.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => {
+                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    return vec![x];
+                }
             }
         }
-        else {
-            x.headers.insert("properties_service_name".to_string(), prop_str);
-        }
-         prop_str = format!("{whoami}.{property}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="request_size",
-                                                      value=self.filter_state["request.total_size"].string_data.as_ref().unwrap().to_string());
-                                             
-        if x.headers.contains_key("properties_request_size") {
-            if !x.headers["properties_request_size"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(&prop_str);
-            }
-        }
-        else {
-            x.headers.insert("properties_request_size".to_string(), prop_str);
-        }
-         
-        self.store_headers(x.clone());
-        return vec!(x);
+
+        // Insert properties to collect
+        let mut prop_tuple;
+        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   "service_name".to_string(), 
+                                                   self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
+                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   "request_size".to_string(), 
+                                                   self.filter_state["request.total_size"].clone());
+                                             ferried_data.unassigned_properties.push(prop_tuple); 
+
+        // Return ferried data to x, and store headers
+        put_ferried_data_in_hdrs(&mut ferried_data, &mut x.headers);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        // 0. Look up stored baggage, and merge it
         x.headers = self.merge_headers(x.uid, x.headers);
-
-        assert!(x.headers.contains_key("properties_path"));
 
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
-        let mut storage_rpc : Option<Rpc> = None;
-        let mut have_trace_level_attributes = true;
+        let mut storage_rpc : Rpc;
 
-        // calculate UDFs and store result, and check trace level properties
-        if self.whoami.as_ref().unwrap() == "productpage-v1" {
+        // 1. retrieve our ferried data, containing the newly merged
+        //    baggage
+        let mut ferried_data: FerriedData;
+        if !original_rpc.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+            }
+        }
+
+        // 2. calculate UDFs and store result, and check trace level properties
+        let root_id = "productpage-v1";
+            if self.whoami.as_ref().unwrap() == root_id {
          let mut trace_prop_str : String;
  
-                let mut trace_prop_str = "productpage-v1.request_size==1".to_string();
-                if x.headers.contains_key("properties_request_size") {
-                    if !x.headers["properties_request_size"].contains(&trace_prop_str) { return vec!(x); }
+                let root_node = utils::get_node_with_id(&ferried_data.trace_graph, "productpage-v1".to_string()).unwrap();
+                if ! ( ferried_data.trace_graph.node_weight(root_node).unwrap().1.contains_key("request_size") &&
+                    ferried_data.trace_graph.node_weight(root_node).unwrap().1["request_size"] == "1" ){
+                    // TODO:  replace ferried_data
+                    match serde_json::to_string(&ferried_data) {
+                        Ok(fd_str) => {
+                            original_rpc.headers.insert("ferried_data".to_string(), fd_str);
+                            return vec![original_rpc];
+                        }
+                        Err(e) => {
+                            print!("could not serialize baggage {0}
+", e);
+                            return vec![original_rpc];
+                        }
+                     }
+                     return vec![original_rpc];
                 }
                         } 
 
-        let mut trace_graph = self.create_trace_graph(x.clone());
-        let mapping = find_mapping_shamir_centralized(
-            &trace_graph,
-            self.target_graph.as_ref().unwrap(),
-        );
-        if mapping.is_some() {
-            let m = mapping.unwrap();
-            let mut value : String;
-            // TODO: do return stuff
-            let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
+        // 3. perform isomorphism and possibly return if root node
+        if self.whoami.as_ref().unwrap() == root_id {
+            let mapping = find_mapping_shamir_centralized(
+                &ferried_data.trace_graph,
+                self.target_graph.as_ref().unwrap(),
+            );
+            if mapping.is_some() {
+                let m = mapping.unwrap();
+                let mut value : String;
+                let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
         if node_ptr.is_none() {
            print!("WARNING Node a not found");
-                return vec!(x);
+                return vec![original_rpc];
         }
         let mut trace_node_index = None;
         for map in m {
@@ -271,37 +333,43 @@ impl Filter {
                 break;
             }
         }
-        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request_size") {
+        if trace_node_index == None || !&ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request_size") {
             // we have not yet collected the return property or have a mapping error
-            return vec!(x);
+            return vec![original_rpc];
         }
-        let mut ret_request_size = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
+        let mut ret_request_size = &ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
 
         value = ret_request_size.to_string();
  
-            let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
-            result_rpc
-                .headers
-                .insert("dest".to_string(), "storage".to_string());
-            result_rpc
-                .headers
-                .insert("direction".to_string(), "request".to_string());
-            result_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
-            storage_rpc = Some(result_rpc);
-            return vec!(x, storage_rpc.unwrap());
-       }
-       return vec!(x);
 
+                // Now you have the return value, so
+                // 3a. Make a storage rpc
+                storage_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
+                storage_rpc
+                    .headers
+                    .insert("dest".to_string(), "storage".to_string());
+                storage_rpc
+                    .headers
+                    .insert("direction".to_string(), "request".to_string());
+                storage_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
+
+                // 3b. Put baggage into regular rpc
+                put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+                return vec![original_rpc, storage_rpc];
+            }
+       }
+       put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+       return vec![original_rpc];
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
         x.headers = self.merge_headers(x.uid, x.headers);
-        return vec!(x);
+        return vec![x];
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        self.store_headers(x.clone());
-        return vec!(x);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
 

--- a/example_queries/request_size_avg.rs.ref
+++ b/example_queries/request_size_avg.rs.ref
@@ -10,11 +10,34 @@ extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct Property {
+    entity: String,
+    property_name: String,
+    value: String,
+}
 
+impl Property {
+    fn default() -> Property {
+        Property {
+            entity: String::new(),
+            property_name: String::new(),
+            value: String::new()
+        }
+    }
+
+    fn new(entity: String, property_name: String, value: String) -> Property {
+        Property {
+            entity,
+            property_name,
+            value
+        }
+    }
+}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FerriedData {
     trace_graph: Graph<(String, IndexMap<String, String>), String>,
-    unassigned_properties: Vec<(String, String, String)>, // entity property value
+    unassigned_properties: Vec<Property>, // entity property value
 }
 
 impl FerriedData {
@@ -30,10 +53,10 @@ impl FerriedData {
     // and associate them with those nodes
     fn assign_properties(&mut self) {
         let mut to_delete = Vec::new();
-        for property in &self.unassigned_properties {
-            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+        for property in &mut self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.entity.clone());
             if node.is_some() {
-                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.property_name.clone(), property.value.clone());
                 to_delete.push(property.clone());
             }
         }
@@ -48,7 +71,7 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
             hdr.insert("ferried_data".to_string(), stored_data_string);
         }
         Err(e) => {
-            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            log::error!("ERROR:  could not translate stored data to json string: {0}\n", e);
         }
     }
 }
@@ -104,7 +127,7 @@ impl Filter {
 
     pub fn set_whoami(&mut self) {
         if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
-            print!("WARNING: filter was initialized without envoy properties and thus cannot function");
+            log::warn!("filter was initialized without envoy properties and thus cannot function");
             return;
         }
         let my_node = self
@@ -116,7 +139,7 @@ impl Filter {
     pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
         // If you don't have data, nothing to store
         if !headers.contains_key("ferried_data") { 
-            print!("WARNING: no ferried data\n");
+            log::warn!("no ferried data\n");
             return;
         }
         let uid = uid_64.to_string();
@@ -131,11 +154,11 @@ impl Filter {
 
         match serde_json::from_str(&headers["ferried_data"]) {
             Ok(d) => { data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
         match serde_json::from_str(&self.envoy_shared_data[&uid]) {
             Ok(d) => { stored_data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
 
 
@@ -157,7 +180,7 @@ impl Filter {
                     stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
                 }
                 None => {
-                    print!("Error:  no edge endpoints found \n");
+                    log::error!("no edge endpoints found \n");
                     return;
                 }
             }
@@ -175,7 +198,7 @@ impl Filter {
                 self.envoy_shared_data.insert(uid, stored_data_string);
             }
             Err(e) => {
-                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                log::error!("could not translate stored data to json string: {0}\n", e);
             }
         }
 
@@ -212,7 +235,7 @@ impl Filter {
                     }
                 }
                 Err(e) => {
-                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                    log::error!("could not parse envoy shared data: {0}\n", e);
                 }
 
             }
@@ -246,7 +269,7 @@ impl Filter {
             match serde_json::from_str(&x.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
                 Err(e) => {
-                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    log::error!("could not translate stored data to json string: {0}\n", e);
                     return vec![x];
                 }
             }
@@ -254,10 +277,10 @@ impl Filter {
 
         // Insert properties to collect
         let mut prop_tuple;
-        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+        prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    "service_name".to_string(), 
                                                    self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
-                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    "request_size".to_string(), 
                                                    self.filter_state["request.total_size"].clone());
                                              ferried_data.unassigned_properties.push(prop_tuple); 
@@ -284,7 +307,7 @@ impl Filter {
         } else {
             match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
-                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+                Err(e) => { log::error!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
             }
         }
 
@@ -303,7 +326,7 @@ impl Filter {
                             return vec![original_rpc];
                         }
                         Err(e) => {
-                            print!("could not serialize baggage {0}
+                            log::error!("could not serialize baggage {0}
 ", e);
                             return vec![original_rpc];
                         }
@@ -323,7 +346,7 @@ impl Filter {
                 let mut value : String;
                 let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), "a".to_string());
         if node_ptr.is_none() {
-           print!("WARNING Node a not found");
+           log::warn!("Node a not found");
                 return vec![original_rpc];
         }
         let mut trace_node_index = None;

--- a/example_queries/request_size_avg.rs.ref
+++ b/example_queries/request_size_avg.rs.ref
@@ -81,12 +81,6 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
 
 
 
-// This represents a piece of state of the filter
-// it contains information that we get from calling getValue in the real filters
-// TODO:  since we no longer use these to define UDFs, we have no need for it
-// to be anything other than a string.  We should simplify it to simply have
-// an Option<String> for every possible envoy value
-
 #[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,

--- a/example_queries/request_size_avg_trace_attr.rs.ref
+++ b/example_queries/request_size_avg_trace_attr.rs.ref
@@ -2,11 +2,57 @@ use rpc_lib::rpc::Rpc;
 use indexmap::map::IndexMap;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
-use petgraph::Outgoing;
+use petgraph::Incoming;
 use graph_utils::utils;
 use graph_utils::iso::find_mapping_shamir_centralized;
+use serde::{Serialize, Deserialize};
+extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FerriedData {
+    trace_graph: Graph<(String, IndexMap<String, String>), String>,
+    unassigned_properties: Vec<(String, String, String)>, // entity property value
+}
+
+impl FerriedData {
+    fn default() -> FerriedData {
+        FerriedData {
+            trace_graph: Graph::new(),
+            unassigned_properties: Vec::new(),
+            
+        }
+    }
+
+    // take any unassigned properties that apply to nodes in the graph,
+    // and associate them with those nodes
+    fn assign_properties(&mut self) {
+        let mut to_delete = Vec::new();
+        for property in &self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+            if node.is_some() {
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                to_delete.push(property.clone());
+            }
+        }
+        self.unassigned_properties.retain(|x| !to_delete.contains(&x));
+
+    }
+}
+
+fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
+    match serde_json::to_string(fd) {
+        Ok(stored_data_string) => {
+            hdr.insert("ferried_data".to_string(), stored_data_string);
+        }
+        Err(e) => {
+            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+        }
+    }
+}
+
 
 // user defined functions:
 
@@ -19,33 +65,11 @@ pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 // an Option<String> for every possible envoy value
 
 #[derive(Clone, Debug)]
-pub struct State {
-    pub type_of_state: Option<String>,
-    pub string_data: Option<String>,
-}
-
-impl State {
-    pub fn new() -> State {
-        State {
-            type_of_state: None,
-            string_data: None,
-        }
-    }
-
-    pub fn new_with_str(str_data: String) -> State {
-        State {
-            type_of_state: Some(String::from("String")),
-            string_data: Some(str_data),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,
     pub target_graph: Option<Graph<(String, IndexMap<String, String>), String>>,
-    pub filter_state: IndexMap<String, State>,
-    pub envoy_shared_data: IndexMap<String, String>,
+    pub filter_state: IndexMap<String, String>,
+    pub envoy_shared_data: IndexMap<String, String>, // trace ID to stored ferried data as string 
     pub collected_properties: Vec<String>, //properties to collect
 }
 
@@ -63,14 +87,10 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
-        let mut hash = IndexMap::new();
-        for key in string_data.keys() {
-            hash.insert(key.clone(), State::new_with_str(string_data[key].clone()));
-        }
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,
-                                   filter_state: hash,
+                                   filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
                                    collected_properties: vec!("service_name".to_string(), "request_size".to_string(),  ),
                                }))
@@ -83,87 +103,123 @@ impl Filter {
     }
 
     pub fn set_whoami(&mut self) {
-        let my_node_wrapped = self
-            .filter_state
-            .get("node.metadata.WORKLOAD_NAME");
-        if my_node_wrapped.is_none() {
+        if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
             print!("WARNING: filter was initialized without envoy properties and thus cannot function");
             return;
         }
-        let my_node = my_node_wrapped
-            .unwrap()
-            .string_data
-            .clone()
-            .unwrap();
+        let my_node = self
+            .filter_state["node.metadata.WORKLOAD_NAME"].clone();
         self.whoami = Some(my_node);
         assert!(self.whoami.is_some());
     }
 
-    pub fn store_headers(&mut self, x: Rpc) {
-        // store path as well as properties
-        let prop_str = format!("{uid}_properties_path", uid=x.uid);
-        if x.headers.contains_key("properties_path") {
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(",");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(&x.headers["properties_path"]);
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(";");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(self.whoami.as_ref().unwrap());
-            }
-            else {
-                // add yourself
-                let mut cur_path = x.headers["properties_path"].clone();
-                cur_path.push_str(";");
-                cur_path.push_str(self.whoami.as_ref().unwrap());
-                self.envoy_shared_data.insert(prop_str, cur_path);
-            }
+    pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
+        // If you don't have data, nothing to store
+        if !headers.contains_key("ferried_data") { 
+            print!("WARNING: no ferried data\n");
+            return;
         }
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=x.uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if x.headers.contains_key(&prop_key) {
-                if self.envoy_shared_data.contains_key(&prop_str) { // concatenate with comma if not duplicate
-                    // make lists of properties
-                    let properties_unified = self.envoy_shared_data[&prop_str].clone();
-                    let mut properties : Vec<String> = properties_unified.split(",").map(|s| s.to_string()).collect();
-                    let cur_properties_unified = x.headers[&prop_key].clone();
-                    let mut cur_properties : Vec<String> = cur_properties_unified.split(",").map(|s| s.to_string()).collect();
+        let uid = uid_64.to_string();
+        // If there is no data stored, you needn't merge - just throw it in
+        if !self.envoy_shared_data.contains_key(&uid) {
+            self.envoy_shared_data.insert(uid.clone(), headers["ferried_data"].clone());
+        }
 
-                    // merge lists and remove duplicates
-                    properties.append(&mut cur_properties);
-                    properties.sort_unstable(); // must sort for dedup to work
-                    properties.dedup();
+        // Else, we merge in 2 parts, for each of the struct values
+        let mut data: FerriedData;
+        let mut stored_data: FerriedData;
 
-                    // store result
-                    let property_string_to_store = properties.join(",");
-                    self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store.clone());
-                } else {
-                    self.envoy_shared_data.insert(prop_str.clone(), x.headers[&prop_key].clone());
+        match serde_json::from_str(&headers["ferried_data"]) {
+            Ok(d) => { data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+        match serde_json::from_str(&self.envoy_shared_data[&uid]) {
+            Ok(d) => { stored_data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+
+
+        // 2. Merge the graphs by simply adding it - later, when we merge, we will
+        //    make a root
+
+        // add node
+        for node in data.trace_graph.node_indices() {
+            stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap().clone());
+        }
+        // add edges
+        for edge in data.trace_graph.edge_indices() {
+            match data.trace_graph.edge_endpoints(edge) {
+                Some((edge0, edge1)) => {
+                    let edge0_weight = &data.trace_graph.node_weight(edge0).unwrap().0;
+                    let edge1_weight = &data.trace_graph.node_weight(edge1).unwrap().0;
+                    let edge0_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge0_weight.to_string()).unwrap();
+                    let edge1_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge1_weight.to_string()).unwrap();
+                    stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
+                }
+                None => {
+                    print!("Error:  no edge endpoints found \n");
+                    return;
                 }
             }
         }
+
+        // 3. merge unassigned properties
+        //    these are properties we have collected but are not yet in the graph
+        stored_data.unassigned_properties.append(&mut data.unassigned_properties);
+        stored_data.unassigned_properties.sort_unstable();
+        stored_data.unassigned_properties.dedup();
+        stored_data.assign_properties();
+
+        match serde_json::to_string(&stored_data) {
+            Ok(stored_data_string) => {
+                self.envoy_shared_data.insert(uid, stored_data_string);
+            }
+            Err(e) => {
+                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            }
+        }
+
     }
 
     pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: IndexMap<String, String>) -> IndexMap<String, String> {
-        // if we are a response, we should do path bookkeeping
-        if new_rpc_headers["direction"] == "response" {
-            let prop_str = format!("{uid}_properties_path", uid=uid);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert("properties_path".to_string(), self.envoy_shared_data[&prop_str].clone());
-            }
-            else { new_rpc_headers.insert("properties_path".to_string(), self.whoami.as_ref().unwrap().clone()); }
-        }
+        let uid_str = uid.to_string();
+        let mut my_indexmap = IndexMap::new();
+        my_indexmap.insert("node.metadata.WORKLOAD_NAME".to_string(), self.whoami.as_ref().unwrap().clone());
 
-        // all other properties
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert(prop_key, self.envoy_shared_data[&prop_str].clone());
-            } else {
-                if new_rpc_headers["direction"] != "request" { 
-                    println!("WARNING: could not find value for {0}", prop_str); 
+        if self.envoy_shared_data.contains_key(&uid_str) {
+            match serde_json::from_str(&self.envoy_shared_data[&uid_str]) {
+                Ok(d) => {
+                    // 1. TODO:  if needed, do things to set S
+                    // 2. If response, add yourself as root
+                    if new_rpc_headers["direction"] == "response" {
+                        let mut data: FerriedData = d;
+                        let mut previous_roots = Vec::new();
+                        for node in data.trace_graph.node_indices() {
+                            if data.trace_graph.neighbors_directed(node, Incoming).count() == 0 {
+                                previous_roots.push(node);
+                            }
+                        }
+                        let me = data.trace_graph.add_node(
+                            (self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+    
+                        for previous_root in previous_roots {
+                            data.trace_graph.add_edge(me, previous_root, String::new());
+                        }
+                        data.assign_properties();
+
+                        // Finally, put all the data back in the headers
+                        put_ferried_data_in_hdrs(&mut data, &mut new_rpc_headers);
+                    }
                 }
+                Err(e) => {
+                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                }
+
             }
+        } else {
+            let mut new_ferried_data = FerriedData::default();
+            new_ferried_data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+            put_ferried_data_in_hdrs(&mut new_ferried_data, &mut new_rpc_headers);
         }
         return new_rpc_headers;
     }
@@ -181,116 +237,128 @@ impl Filter {
  
     }
 
-    pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, IndexMap<String, String>), String> {
-        let trace;
-        let mut path = mod_rpc.headers["properties_path"].clone();
-        let mut properties = Vec::new();
-        for header in mod_rpc.headers.keys() {
-            if header.contains("properties_") && header != "properties_path" {
-                properties.push(mod_rpc.headers[header].clone().replace("properties_", ""));
-            }
-        }
-        let prop_to_trace = properties.join(",");
-        trace = utils::generate_trace_graph_from_headers(path, prop_to_trace);
-        return trace;
-    }
-
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let mut prop_str;
-        prop_str = format!("{whoami}.{property}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="service_name",
-                                                      value=self.filter_state["node.metadata.WORKLOAD_NAME"].string_data.as_ref().unwrap().to_string());
-                                             
-        if x.headers.contains_key("properties_service_name") {
-            if !x.headers["properties_service_name"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_service_name".to_string()).unwrap().push_str(&prop_str);
+        // Fetch ferried data
+        let mut ferried_data: FerriedData;
+        if !x.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&x.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => {
+                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    return vec![x];
+                }
             }
         }
-        else {
-            x.headers.insert("properties_service_name".to_string(), prop_str);
-        }
-         prop_str = format!("{whoami}.{property}=={value}",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property="request_size",
-                                                      value=self.filter_state["request.total_size"].string_data.as_ref().unwrap().to_string());
-                                             
-        if x.headers.contains_key("properties_request_size") {
-            if !x.headers["properties_request_size"].contains(&prop_str) { // don't add our properties if they have already been added
-                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(",");
-                x.headers.get_mut(&"properties_request_size".to_string()).unwrap().push_str(&prop_str);
-            }
-        }
-        else {
-            x.headers.insert("properties_request_size".to_string(), prop_str);
-        }
-         
-        self.store_headers(x.clone());
-        return vec!(x);
+
+        // Insert properties to collect
+        let mut prop_tuple;
+        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   "service_name".to_string(), 
+                                                   self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
+                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   "request_size".to_string(), 
+                                                   self.filter_state["request.total_size"].clone());
+                                             ferried_data.unassigned_properties.push(prop_tuple); 
+
+        // Return ferried data to x, and store headers
+        put_ferried_data_in_hdrs(&mut ferried_data, &mut x.headers);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        // 0. Look up stored baggage, and merge it
         x.headers = self.merge_headers(x.uid, x.headers);
-
-        assert!(x.headers.contains_key("properties_path"));
 
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
-        let mut storage_rpc : Option<Rpc> = None;
-        let mut have_trace_level_attributes = true;
+        let mut storage_rpc : Rpc;
 
-        // calculate UDFs and store result, and check trace level properties
-        if self.whoami.as_ref().unwrap() == "productpage-v1" {
+        // 1. retrieve our ferried data, containing the newly merged
+        //    baggage
+        let mut ferried_data: FerriedData;
+        if !original_rpc.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+            }
+        }
+
+        // 2. calculate UDFs and store result, and check trace level properties
+        let root_id = "productpage-v1";
+            if self.whoami.as_ref().unwrap() == root_id {
          let mut trace_prop_str : String;
  
-                let mut trace_prop_str = "productpage-v1.request_size==1".to_string();
-                if x.headers.contains_key("properties_request_size") {
-                    if !x.headers["properties_request_size"].contains(&trace_prop_str) { return vec!(x); }
+                let root_node = utils::get_node_with_id(&ferried_data.trace_graph, "productpage-v1".to_string()).unwrap();
+                if ! ( ferried_data.trace_graph.node_weight(root_node).unwrap().1.contains_key("request_size") &&
+                    ferried_data.trace_graph.node_weight(root_node).unwrap().1["request_size"] == "1" ){
+                    // TODO:  replace ferried_data
+                    match serde_json::to_string(&ferried_data) {
+                        Ok(fd_str) => {
+                            original_rpc.headers.insert("ferried_data".to_string(), fd_str);
+                            return vec![original_rpc];
+                        }
+                        Err(e) => {
+                            print!("could not serialize baggage {0}
+", e);
+                            return vec![original_rpc];
+                        }
+                     }
+                     return vec![original_rpc];
                 }
                         } 
 
-        let mut trace_graph = self.create_trace_graph(x.clone());
-        let mapping = find_mapping_shamir_centralized(
-            &trace_graph,
-            self.target_graph.as_ref().unwrap(),
-        );
-        if mapping.is_some() {
-            let m = mapping.unwrap();
-            let mut value : String;
-            // TODO: do return stuff
-            let trace_node_index = utils::get_node_with_id(&trace_graph, "productpage-v1".to_string());
+        // 3. perform isomorphism and possibly return if root node
+        if self.whoami.as_ref().unwrap() == root_id {
+            let mapping = find_mapping_shamir_centralized(
+                &ferried_data.trace_graph,
+                self.target_graph.as_ref().unwrap(),
+            );
+            if mapping.is_some() {
+                let m = mapping.unwrap();
+                let mut value : String;
+                let trace_node_index = utils::get_node_with_id(&ferried_data.trace_graph, "productpage-v1".to_string());
         if trace_node_index.is_none() {
            print!("WARNING Node productpage-v1 not found");
-                return vec!(x);
+                return vec![original_rpc];
         }
-        let mut ret_request_size = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
+        let mut ret_request_size = &ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
 
         value = ret_request_size.to_string();
  
-            let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
-            result_rpc
-                .headers
-                .insert("dest".to_string(), "storage".to_string());
-            result_rpc
-                .headers
-                .insert("direction".to_string(), "request".to_string());
-            result_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
-            storage_rpc = Some(result_rpc);
-            return vec!(x, storage_rpc.unwrap());
-       }
-       return vec!(x);
 
+                // Now you have the return value, so
+                // 3a. Make a storage rpc
+                storage_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
+                storage_rpc
+                    .headers
+                    .insert("dest".to_string(), "storage".to_string());
+                storage_rpc
+                    .headers
+                    .insert("direction".to_string(), "request".to_string());
+                storage_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
+
+                // 3b. Put baggage into regular rpc
+                put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+                return vec![original_rpc, storage_rpc];
+            }
+       }
+       put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+       return vec![original_rpc];
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
         x.headers = self.merge_headers(x.uid, x.headers);
-        return vec!(x);
+        return vec![x];
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        self.store_headers(x.clone());
-        return vec!(x);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
     }
 
 

--- a/example_queries/request_size_avg_trace_attr.rs.ref
+++ b/example_queries/request_size_avg_trace_attr.rs.ref
@@ -81,12 +81,6 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
 
 
 
-// This represents a piece of state of the filter
-// it contains information that we get from calling getValue in the real filters
-// TODO:  since we no longer use these to define UDFs, we have no need for it
-// to be anything other than a string.  We should simplify it to simply have
-// an Option<String> for every possible envoy value
-
 #[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,

--- a/example_queries/request_size_avg_trace_attr.rs.ref
+++ b/example_queries/request_size_avg_trace_attr.rs.ref
@@ -10,11 +10,34 @@ extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct Property {
+    entity: String,
+    property_name: String,
+    value: String,
+}
 
+impl Property {
+    fn default() -> Property {
+        Property {
+            entity: String::new(),
+            property_name: String::new(),
+            value: String::new()
+        }
+    }
+
+    fn new(entity: String, property_name: String, value: String) -> Property {
+        Property {
+            entity,
+            property_name,
+            value
+        }
+    }
+}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FerriedData {
     trace_graph: Graph<(String, IndexMap<String, String>), String>,
-    unassigned_properties: Vec<(String, String, String)>, // entity property value
+    unassigned_properties: Vec<Property>, // entity property value
 }
 
 impl FerriedData {
@@ -30,10 +53,10 @@ impl FerriedData {
     // and associate them with those nodes
     fn assign_properties(&mut self) {
         let mut to_delete = Vec::new();
-        for property in &self.unassigned_properties {
-            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+        for property in &mut self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.entity.clone());
             if node.is_some() {
-                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.property_name.clone(), property.value.clone());
                 to_delete.push(property.clone());
             }
         }
@@ -48,7 +71,7 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
             hdr.insert("ferried_data".to_string(), stored_data_string);
         }
         Err(e) => {
-            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            log::error!("ERROR:  could not translate stored data to json string: {0}\n", e);
         }
     }
 }
@@ -104,7 +127,7 @@ impl Filter {
 
     pub fn set_whoami(&mut self) {
         if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
-            print!("WARNING: filter was initialized without envoy properties and thus cannot function");
+            log::warn!("filter was initialized without envoy properties and thus cannot function");
             return;
         }
         let my_node = self
@@ -116,7 +139,7 @@ impl Filter {
     pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
         // If you don't have data, nothing to store
         if !headers.contains_key("ferried_data") { 
-            print!("WARNING: no ferried data\n");
+            log::warn!("no ferried data\n");
             return;
         }
         let uid = uid_64.to_string();
@@ -131,11 +154,11 @@ impl Filter {
 
         match serde_json::from_str(&headers["ferried_data"]) {
             Ok(d) => { data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
         match serde_json::from_str(&self.envoy_shared_data[&uid]) {
             Ok(d) => { stored_data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
 
 
@@ -157,7 +180,7 @@ impl Filter {
                     stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
                 }
                 None => {
-                    print!("Error:  no edge endpoints found \n");
+                    log::error!("no edge endpoints found \n");
                     return;
                 }
             }
@@ -175,7 +198,7 @@ impl Filter {
                 self.envoy_shared_data.insert(uid, stored_data_string);
             }
             Err(e) => {
-                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                log::error!("could not translate stored data to json string: {0}\n", e);
             }
         }
 
@@ -212,7 +235,7 @@ impl Filter {
                     }
                 }
                 Err(e) => {
-                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                    log::error!("could not parse envoy shared data: {0}\n", e);
                 }
 
             }
@@ -246,7 +269,7 @@ impl Filter {
             match serde_json::from_str(&x.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
                 Err(e) => {
-                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    log::error!("could not translate stored data to json string: {0}\n", e);
                     return vec![x];
                 }
             }
@@ -254,10 +277,10 @@ impl Filter {
 
         // Insert properties to collect
         let mut prop_tuple;
-        prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+        prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    "service_name".to_string(), 
                                                    self.filter_state["node.metadata.WORKLOAD_NAME"].clone());
-                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                             ferried_data.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    "request_size".to_string(), 
                                                    self.filter_state["request.total_size"].clone());
                                              ferried_data.unassigned_properties.push(prop_tuple); 
@@ -284,7 +307,7 @@ impl Filter {
         } else {
             match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
-                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+                Err(e) => { log::error!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
             }
         }
 
@@ -303,7 +326,7 @@ impl Filter {
                             return vec![original_rpc];
                         }
                         Err(e) => {
-                            print!("could not serialize baggage {0}
+                            log::error!("could not serialize baggage {0}
 ", e);
                             return vec![original_rpc];
                         }
@@ -323,7 +346,7 @@ impl Filter {
                 let mut value : String;
                 let trace_node_index = utils::get_node_with_id(&ferried_data.trace_graph, "productpage-v1".to_string());
         if trace_node_index.is_none() {
-           print!("WARNING Node productpage-v1 not found");
+           log::warn!("Node productpage-v1 not found");
                 return vec![original_rpc];
         }
         let mut ret_request_size = &ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];

--- a/example_udfs/height.rs
+++ b/example_udfs/height.rs
@@ -3,12 +3,12 @@
 // mid_func: mid_height
 // id: height
 
-fn leaf_height(_graph: Graph<(String, IndexMap<String, String>), String>) -> u32 {
+fn leaf_height(_graph: &Graph<(String, IndexMap<String, String>), String>) -> u32 {
     return 0;
 }
 
 // TODO:  must children's responses always be in string form?  can we generalize?
-fn mid_height(_graph: Graph<(String, IndexMap<String, String>), String>, children_responses: Vec<String>) -> u32 {
+fn mid_height(_graph: &Graph<(String, IndexMap<String, String>), String>, children_responses: Vec<String>) -> u32 {
     let mut max = 0;
     for response in children_responses {
         let response_as_u32 = response.parse::<u32>();

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -2,14 +2,16 @@ use rpc_lib::rpc::Rpc;
 use indexmap::map::IndexMap;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
-use petgraph::Outgoing;
+use petgraph::Incoming;
 use graph_utils::utils;
 use graph_utils::iso::find_mapping_shamir_centralized;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
+extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
-#[derive(Debug, Serialize)]
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FerriedData {
     set_s: IndexMap<(NodeIndex, NodeIndex), IndexMap<NodeIndex, Option<Vec<(NodeIndex, NodeIndex)>>>>,
     trace_graph: Graph<(String, IndexMap<String, String>), String>,
@@ -86,81 +88,117 @@ impl Filter {
         assert!(self.whoami.is_some());
     }
 
-    pub fn store_headers(&mut self, x: Rpc) {
+    pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
         // If you don't have data, nothing to store
-        if !x.headers.contains_key("ferried_data") { 
+        if headers.contains_key("ferried_data") { 
             print!("WARNING: no ferried data\n");
         }
+        let uid = uid_64.to_string();
         // If there is no data stored, you needn't merge - just throw it in
-        if !self.envoy_shared_data.contains_key(x.uid) {
-            self.envoy_shared_data.insert(x.uid, x.headers["ferried_data"]);
+        if !self.envoy_shared_data.contains_key(&uid) {
+            self.envoy_shared_data.insert(uid.clone(), headers["ferried_data"].clone());
         }
 
         // Else, we merge in 3 parts, for each of the struct values
-        let data: FerriedData = serde_json::from_str(x.headers["ferried_data"]);
-        let stored_data: FerriedData = serde_json::from_str(self.envoy_shared_data[x.uid]);
+        let mut data: FerriedData;
+        let mut stored_data: FerriedData;
+
+        match serde_json::from_str(&headers["ferried_data"]) {
+            Ok(d) => { data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+        match serde_json::from_str(&self.envoy_shared_data[&uid]) {
+            Ok(d) => { stored_data = d; }
+            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+        }
 
         // 1. TODO: merge set_s
 
-        // 2. Merge the graphs by becoming another child of root
+        // 2. Merge the graphs by simply adding it - later, when we merge, we will
+        //    make a root
 
-        let mut root_stored = utils::find_root(&stored_data.trace_graph);
-        let mut root_new = utils::find_root(&data.trace_graph);
-
-        // add nodes
+        // add node
         for node in data.trace_graph.node_indices() {
-            stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap());
+            stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap().clone());
         }
-
+        /*
         // add edges
         for edge in data.trace_graph.edge_indices() {
             let edge0_weight = data.trace_graph.node_weight(edge.0).unwrap();
             let edge1_weight = data.trace_graph.node_weight(edge.1).unwrap();
-            let edge0_in_stored_graph = get_node_with_id(stored_data.trace_graph, edge0_weight);
-            let edge1_in_stored_graph = get_node_with_id(stored_data.trace_graph, edge1_weight);
+            let edge0_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge0_weight);
+            let edge1_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge1_weight);
             stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
         }
-
-        // add link between roots
-        let root_new_weight = data.trace_graph.node_weight(root_new).unwrap();
-        let root_new_in_stored = get_node_with_id(stored_data.trace_graph, root_new_weight);
-        stored_data.trace_graph.add_edge(
-            root_stored,
-            root_new_in_stored,
-            String::new(),
-        );
+        */
 
         // 3. merge unassigned properties
         //    these are properties we have collected but are not yet in the graph
-        stored_data.unassigned_properties.append(data.unassigned_properties);
+        stored_data.unassigned_properties.append(&mut data.unassigned_properties);
         stored_data.unassigned_properties.sort_unstable();
         stored_data.unassigned_properties.dedup();
 
-        self.envoy_shared_data.insert(x.uid, serde_json::to_str(stored_data));
+        match serde_json::to_string(&stored_data) {
+            Ok(stored_data_string) => {
+                self.envoy_shared_data.insert(uid, stored_data_string);
+            }
+            Err(e) => {
+                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            }
+        }
 
     }
 
     pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: IndexMap<String, String>) -> IndexMap<String, String> {
-        // if we are a response, we should do path bookkeeping
-        if new_rpc_headers["direction"] == "response" {
-            let prop_str = format!("{uid}_properties_path", uid=uid);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert("properties_path".to_string(), self.envoy_shared_data[&prop_str].clone());
-            }
-            else { new_rpc_headers.insert("properties_path".to_string(), self.whoami.as_ref().unwrap().clone()); }
-        }
+        let uid_str = uid.to_string();
+        let mut my_indexmap = IndexMap::new();
+        my_indexmap.insert("node.metadata.WORKLOAD_NAME".to_string(), self.whoami.as_ref().unwrap().clone());
 
-        // all other properties
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                new_rpc_headers.insert(prop_key, self.envoy_shared_data[&prop_str].clone());
-            } else {
-                if new_rpc_headers["direction"] != "request" { 
-                    println!("WARNING: could not find value for {0}", prop_str); 
+        if self.envoy_shared_data.contains_key(&uid_str) {
+            match serde_json::from_str(&self.envoy_shared_data[&uid_str]) {
+                Ok(d) => {
+                    // 1. TODO:  if needed, do things to set S
+                    // 2. Add yourself as root
+                    let mut data: FerriedData = d;
+                    let mut previous_roots = Vec::new();
+                    for node in data.trace_graph.node_indices() {
+                        if data.trace_graph.neighbors_directed(node, Incoming).count() == 0 {
+                            previous_roots.push(node);
+                        }
+                    }
+                    let me = data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+
+                    for previous_root in previous_roots {
+                        data.trace_graph.add_edge(me, previous_root, String::new());
+                    }
+                    match serde_json::to_string(&data) {
+                        Ok(stored_data_string) => {
+                            new_rpc_headers.insert("ferried_data".to_string(), stored_data_string);
+                        }
+                        Err(e) => {
+                            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                }
+
+            }
+        } else {
+            // just add yourself as root
+            let mut new_ferried_data = FerriedData::default();
+            new_ferried_data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+            new_rpc_headers.insert("ferried_data".to_string(), self.envoy_shared_data[&uid_str].clone());
+            match serde_json::to_string(&new_ferried_data) {
+                Ok(stored_data_string) => {
+                    new_rpc_headers.insert("ferried_data".to_string(), stored_data_string);
+                }
+                Err(e) => {
+                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
                 }
             }
+
         }
         return new_rpc_headers;
     }
@@ -186,24 +224,34 @@ impl Filter {
     pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
         let mut prop_str;
         {{#each request_blocks}}{{{this}}} {{/each}}
-        self.store_headers(x.clone());
+        self.store_headers(x.uid, x.headers.clone());
         return vec!(x);
     }
 
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
         x.headers = self.merge_headers(x.uid, x.headers);
 
-        assert!(x.headers.contains_key("properties_path"));
-
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
         let mut storage_rpc : Option<Rpc> = None;
-        let mut have_trace_level_attributes = true;
 
+        if !original_rpc.headers.contains_key("ferried") {
+            match serde_json::to_string(&FerriedData::default()) {
+                Ok(ferried_data_string) => {
+                    original_rpc.headers.insert("ferried_data".to_string(), ferried_data_string);
+                }
+                Err(e) => {
+                    print!("ERROR:  ferried data could not be turned to a string: {0}\n", e);
+                    return vec![original_rpc];
+                }
+            }
+        }
+        let mut trace_graph = self.create_trace_graph(x.clone());
+
+        /*
         // calculate UDFs and store result, and check trace level properties
         {{#each udf_blocks}}{{{this}}} {{/each}}
 
-        let mut trace_graph = self.create_trace_graph(x.clone());
         let mapping = find_mapping_shamir_centralized(
             &trace_graph,
             self.target_graph.as_ref().unwrap(),
@@ -224,6 +272,7 @@ impl Filter {
             storage_rpc = Some(result_rpc);
             return vec!(x, storage_rpc.unwrap());
        }
+       */
        return vec!(x);
 
     }
@@ -234,7 +283,7 @@ impl Filter {
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        self.store_headers(x.clone());
+        self.store_headers(x.uid, x.headers.clone());
         return vec!(x);
     }
 

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -13,7 +13,6 @@ pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FerriedData {
-    set_s: IndexMap<(NodeIndex, NodeIndex), IndexMap<NodeIndex, Option<Vec<(NodeIndex, NodeIndex)>>>>,
     trace_graph: Graph<(String, IndexMap<String, String>), String>,
     unassigned_properties: Vec<(String, String, String)>, // entity property value
 }
@@ -21,7 +20,6 @@ pub struct FerriedData {
 impl FerriedData {
     fn default() -> FerriedData {
         FerriedData {
-            set_s: IndexMap::new(),
             trace_graph: Graph::new(),
             unassigned_properties: Vec::new(),
             
@@ -100,7 +98,7 @@ impl Filter {
             self.envoy_shared_data.insert(uid.clone(), headers["ferried_data"].clone());
         }
 
-        // Else, we merge in 3 parts, for each of the struct values
+        // Else, we merge in 2 parts, for each of the struct values
         let mut data: FerriedData;
         let mut stored_data: FerriedData;
 
@@ -113,7 +111,6 @@ impl Filter {
             Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
         }
 
-        // 1. TODO: merge set_s
 
         // 2. Merge the graphs by simply adding it - later, when we merge, we will
         //    make a root
@@ -191,6 +188,18 @@ impl Filter {
                         for previous_root in previous_roots {
                             data.trace_graph.add_edge(me, previous_root, String::new());
                         }
+                        // Then, once we've added ourselves as root, add any unassigned properties that belong to us
+                        let mut to_delete = Vec::new();
+                        for property in &data.unassigned_properties {
+                            let node = utils::get_node_with_id(&data.trace_graph, property.0.clone());
+                            if node.is_some() {
+                                data.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                                to_delete.push(property.clone());
+                            }
+                        }
+                        data.unassigned_properties.retain(|x| !to_delete.contains(&x));
+
+                        // Finally, put all the data back in the headers
                         match serde_json::to_string(&data) {
                             Ok(stored_data_string) => {
                                 new_rpc_headers.insert("ferried_data".to_string(), stored_data_string);
@@ -329,8 +338,6 @@ impl Filter {
                 return vec![original_rpc];
             }
        }
-       return vec![original_rpc];
-
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -10,11 +10,34 @@ extern crate serde_json;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct Property {
+    entity: String,
+    property_name: String,
+    value: String,
+}
 
+impl Property {
+    fn default() -> Property {
+        Property {
+            entity: String::new(),
+            property_name: String::new(),
+            value: String::new()
+        }
+    }
+
+    fn new(entity: String, property_name: String, value: String) -> Property {
+        Property {
+            entity,
+            property_name,
+            value
+        }
+    }
+}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FerriedData {
     trace_graph: Graph<(String, IndexMap<String, String>), String>,
-    unassigned_properties: Vec<(String, String, String)>, // entity property value
+    unassigned_properties: Vec<Property>, // entity property value
 }
 
 impl FerriedData {
@@ -30,10 +53,10 @@ impl FerriedData {
     // and associate them with those nodes
     fn assign_properties(&mut self) {
         let mut to_delete = Vec::new();
-        for property in &self.unassigned_properties {
-            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+        for property in &mut self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.entity.clone());
             if node.is_some() {
-                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.property_name.clone(), property.value.clone());
                 to_delete.push(property.clone());
             }
         }
@@ -48,7 +71,7 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
             hdr.insert("ferried_data".to_string(), stored_data_string);
         }
         Err(e) => {
-            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+            log::error!("ERROR:  could not translate stored data to json string: {0}\n", e);
         }
     }
 }
@@ -104,7 +127,7 @@ impl Filter {
 
     pub fn set_whoami(&mut self) {
         if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
-            print!("WARNING: filter was initialized without envoy properties and thus cannot function");
+            log::warn!("filter was initialized without envoy properties and thus cannot function");
             return;
         }
         let my_node = self
@@ -116,7 +139,7 @@ impl Filter {
     pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
         // If you don't have data, nothing to store
         if !headers.contains_key("ferried_data") { 
-            print!("WARNING: no ferried data\n");
+            log::warn!("no ferried data\n");
             return;
         }
         let uid = uid_64.to_string();
@@ -131,11 +154,11 @@ impl Filter {
 
         match serde_json::from_str(&headers["ferried_data"]) {
             Ok(d) => { data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
         match serde_json::from_str(&self.envoy_shared_data[&uid]) {
             Ok(d) => { stored_data = d; }
-            Err(e) => { print!("could not parse envoy shared data: {0}\n", e); return; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
         }
 
 
@@ -157,7 +180,7 @@ impl Filter {
                     stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
                 }
                 None => {
-                    print!("Error:  no edge endpoints found \n");
+                    log::error!("no edge endpoints found \n");
                     return;
                 }
             }
@@ -175,7 +198,7 @@ impl Filter {
                 self.envoy_shared_data.insert(uid, stored_data_string);
             }
             Err(e) => {
-                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                log::error!("could not translate stored data to json string: {0}\n", e);
             }
         }
 
@@ -212,7 +235,7 @@ impl Filter {
                     }
                 }
                 Err(e) => {
-                    print!("ERROR:  could not parse envoy shared data: {0}\n", e);
+                    log::error!("could not parse envoy shared data: {0}\n", e);
                 }
 
             }
@@ -237,7 +260,7 @@ impl Filter {
             match serde_json::from_str(&x.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
                 Err(e) => {
-                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    log::error!("could not translate stored data to json string: {0}\n", e);
                     return vec![x];
                 }
             }
@@ -269,7 +292,7 @@ impl Filter {
         } else {
             match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
-                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+                Err(e) => { log::error!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
             }
         }
 

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -90,8 +90,9 @@ impl Filter {
 
     pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
         // If you don't have data, nothing to store
-        if headers.contains_key("ferried_data") { 
+        if !headers.contains_key("ferried_data") { 
             print!("WARNING: no ferried data\n");
+            return;
         }
         let uid = uid_64.to_string();
         // If there is no data stored, you needn't merge - just throw it in
@@ -121,16 +122,22 @@ impl Filter {
         for node in data.trace_graph.node_indices() {
             stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap().clone());
         }
-        /*
         // add edges
         for edge in data.trace_graph.edge_indices() {
-            let edge0_weight = data.trace_graph.node_weight(edge.0).unwrap();
-            let edge1_weight = data.trace_graph.node_weight(edge.1).unwrap();
-            let edge0_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge0_weight);
-            let edge1_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge1_weight);
-            stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
+            match data.trace_graph.edge_endpoints(edge) {
+                Some((edge0, edge1)) => {
+                    let edge0_weight = &data.trace_graph.node_weight(edge0).unwrap().0;
+                    let edge1_weight = &data.trace_graph.node_weight(edge1).unwrap().0;
+                    let edge0_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge0_weight.to_string()).unwrap();
+                    let edge1_in_stored_graph = utils::get_node_with_id(&stored_data.trace_graph, edge1_weight.to_string()).unwrap();
+                    stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
+                }
+                None => {
+                    print!("Error:  no edge endpoints found \n");
+                    return;
+                }
+            }
         }
-        */
 
         // 3. merge unassigned properties
         //    these are properties we have collected but are not yet in the graph
@@ -186,10 +193,8 @@ impl Filter {
 
             }
         } else {
-            // just add yourself as root
             let mut new_ferried_data = FerriedData::default();
             new_ferried_data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
-            new_rpc_headers.insert("ferried_data".to_string(), self.envoy_shared_data[&uid_str].clone());
             match serde_json::to_string(&new_ferried_data) {
                 Ok(stored_data_string) => {
                     new_rpc_headers.insert("ferried_data".to_string(), stored_data_string);
@@ -207,84 +212,110 @@ impl Filter {
         {{#each target_blocks}}{{{this}}} {{/each}}
     }
 
-    pub fn create_trace_graph(&mut self, mut mod_rpc: Rpc) -> Graph<(String, IndexMap<String, String>), String> {
-        let trace;
-        let mut path = mod_rpc.headers["properties_path"].clone();
-        let mut properties = Vec::new();
-        for header in mod_rpc.headers.keys() {
-            if header.contains("properties_") && header != "properties_path" {
-                properties.push(mod_rpc.headers[header].clone().replace("properties_", ""));
+    pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        // Fetch ferried data
+        let mut ferried_data: FerriedData;
+        if !x.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&x.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => {
+                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                    return vec![x];
+                }
             }
         }
-        let prop_to_trace = properties.join(",");
-        trace = utils::generate_trace_graph_from_headers(path, prop_to_trace);
-        return trace;
-    }
 
-    pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
-        let mut prop_str;
+        // Insert properties to collect
+        let mut prop_tuple;
         {{#each request_blocks}}{{{this}}} {{/each}}
+
+        // Return ferried data to x, and store headers
+        match serde_json::to_string(&ferried_data) {
+            Ok(stored_data_string) => {
+                x.headers.insert("ferried_data".to_string(), stored_data_string);
+            }
+            Err(e) => {
+                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                return vec![x];
+            }
+        }
         self.store_headers(x.uid, x.headers.clone());
-        return vec!(x);
+        return vec![x];
     }
 
     pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        // 0. Look up stored baggage, and merge it
         x.headers = self.merge_headers(x.uid, x.headers);
 
         // at most, we return two rpcs:  one to continue on and one to storage
         let mut original_rpc = x.clone();
-        let mut storage_rpc : Option<Rpc> = None;
+        let mut storage_rpc : Rpc;
 
-        if !original_rpc.headers.contains_key("ferried") {
-            match serde_json::to_string(&FerriedData::default()) {
-                Ok(ferried_data_string) => {
-                    original_rpc.headers.insert("ferried_data".to_string(), ferried_data_string);
-                }
-                Err(e) => {
-                    print!("ERROR:  ferried data could not be turned to a string: {0}\n", e);
-                    return vec![original_rpc];
-                }
+        // 1. retrieve our ferried data, containing the newly merged
+        //    baggage
+        let mut ferried_data: FerriedData;
+        if !original_rpc.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&original_rpc.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
             }
         }
-        let mut trace_graph = self.create_trace_graph(x.clone());
 
-        /*
-        // calculate UDFs and store result, and check trace level properties
+        // 2. calculate UDFs and store result, and check trace level properties
         {{#each udf_blocks}}{{{this}}} {{/each}}
 
-        let mapping = find_mapping_shamir_centralized(
-            &trace_graph,
-            self.target_graph.as_ref().unwrap(),
-        );
-        if mapping.is_some() {
-            let m = mapping.unwrap();
-            let mut value : String;
-            // TODO: do return stuff
-            {{#each response_blocks}}{{{this}}} {{/each}}
-            let mut result_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
-            result_rpc
-                .headers
-                .insert("dest".to_string(), "storage".to_string());
-            result_rpc
-                .headers
-                .insert("direction".to_string(), "request".to_string());
-            result_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
-            storage_rpc = Some(result_rpc);
-            return vec!(x, storage_rpc.unwrap());
+        // 3. perform isomorphism and possibly return if root node
+        if self.whoami.as_ref().unwrap() == "{{root_id}}" {
+            let mapping = find_mapping_shamir_centralized(
+                &ferried_data.trace_graph,
+                self.target_graph.as_ref().unwrap(),
+            );
+            if mapping.is_some() {
+                let m = mapping.unwrap();
+                let mut value : String;
+                {{#each response_blocks}}{{{this}}} {{/each}}
+
+                // Now you have the return value, so
+                // 3a. Make a storage rpc
+                storage_rpc = Rpc::new_with_src(&value, self.whoami.as_ref().unwrap());
+                storage_rpc
+                    .headers
+                    .insert("dest".to_string(), "storage".to_string());
+                storage_rpc
+                    .headers
+                    .insert("direction".to_string(), "request".to_string());
+                storage_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
+
+                // 3b. Put baggage into regular rpc
+                match serde_json::to_string(&ferried_data) {
+                    Ok(fd_str) => {
+                        original_rpc.headers.insert("ferried_data".to_string(), fd_str);
+                        return vec!(original_rpc, storage_rpc);
+
+                    }
+                    Err(e) => {
+                        print!("could not serialize baggage {0}\n", e);
+                        return vec![original_rpc];
+                    }
+                }
+            }
        }
-       */
-       return vec!(x);
+       return vec![original_rpc];
 
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
         x.headers = self.merge_headers(x.uid, x.headers);
-        return vec!(x);
+        return vec![x];
     }
 
     pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
         self.store_headers(x.uid, x.headers.clone());
-        return vec!(x);
+        return vec![x];
     }
 
 

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -81,12 +81,6 @@ fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,Stri
 {{#each udf_table}}{{{this.func_impl}}}{{/each}}
 
 
-// This represents a piece of state of the filter
-// it contains information that we get from calling getValue in the real filters
-// TODO:  since we no longer use these to define UDFs, we have no need for it
-// to be anything other than a string.  We should simplify it to simply have
-// an Option<String> for every possible envoy value
-
 #[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -25,7 +25,34 @@ impl FerriedData {
             
         }
     }
+
+    // take any unassigned properties that apply to nodes in the graph,
+    // and associate them with those nodes
+    fn assign_properties(&mut self) {
+        let mut to_delete = Vec::new();
+        for property in &self.unassigned_properties {
+            let node = utils::get_node_with_id(&self.trace_graph, property.0.clone());
+            if node.is_some() {
+                self.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                to_delete.push(property.clone());
+            }
+        }
+        self.unassigned_properties.retain(|x| !to_delete.contains(&x));
+
+    }
 }
+
+fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
+    match serde_json::to_string(fd) {
+        Ok(stored_data_string) => {
+            hdr.insert("ferried_data".to_string(), stored_data_string);
+        }
+        Err(e) => {
+            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+        }
+    }
+}
+
 
 // user defined functions:
 {{#each udf_table}}{{{this.func_impl}}}{{/each}}
@@ -141,17 +168,7 @@ impl Filter {
         stored_data.unassigned_properties.append(&mut data.unassigned_properties);
         stored_data.unassigned_properties.sort_unstable();
         stored_data.unassigned_properties.dedup();
-
-        // 3a.  If we have any unassigned properties that should be assigned, now is the time
-        let mut to_delete = Vec::new();
-        for property in &stored_data.unassigned_properties {
-            let node = utils::get_node_with_id(&stored_data.trace_graph, property.0.clone());
-            if node.is_some() {
-                stored_data.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
-                to_delete.push(property.clone());
-            }
-        }
-        stored_data.unassigned_properties.retain(|x| !to_delete.contains(&x));
+        stored_data.assign_properties();
 
         match serde_json::to_string(&stored_data) {
             Ok(stored_data_string) => {
@@ -188,26 +205,10 @@ impl Filter {
                         for previous_root in previous_roots {
                             data.trace_graph.add_edge(me, previous_root, String::new());
                         }
-                        // Then, once we've added ourselves as root, add any unassigned properties that belong to us
-                        let mut to_delete = Vec::new();
-                        for property in &data.unassigned_properties {
-                            let node = utils::get_node_with_id(&data.trace_graph, property.0.clone());
-                            if node.is_some() {
-                                data.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
-                                to_delete.push(property.clone());
-                            }
-                        }
-                        data.unassigned_properties.retain(|x| !to_delete.contains(&x));
+                        data.assign_properties();
 
                         // Finally, put all the data back in the headers
-                        match serde_json::to_string(&data) {
-                            Ok(stored_data_string) => {
-                                new_rpc_headers.insert("ferried_data".to_string(), stored_data_string);
-                            }
-                            Err(e) => {
-                                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
-                            }
-                        }
+                        put_ferried_data_in_hdrs(&mut data, &mut new_rpc_headers);
                     }
                 }
                 Err(e) => {
@@ -218,15 +219,7 @@ impl Filter {
         } else {
             let mut new_ferried_data = FerriedData::default();
             new_ferried_data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
-            match serde_json::to_string(&new_ferried_data) {
-                Ok(stored_data_string) => {
-                    new_rpc_headers.insert("ferried_data".to_string(), stored_data_string);
-                }
-                Err(e) => {
-                    print!("ERROR:  could not translate stored data to json string: {0}\n", e);
-                }
-            }
-
+            put_ferried_data_in_hdrs(&mut new_ferried_data, &mut new_rpc_headers);
         }
         return new_rpc_headers;
     }
@@ -255,15 +248,7 @@ impl Filter {
         {{#each request_blocks}}{{{this}}} {{/each}}
 
         // Return ferried data to x, and store headers
-        match serde_json::to_string(&ferried_data) {
-            Ok(stored_data_string) => {
-                x.headers.insert("ferried_data".to_string(), stored_data_string);
-            }
-            Err(e) => {
-                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
-                return vec![x];
-            }
-        }
+        put_ferried_data_in_hdrs(&mut ferried_data, &mut x.headers);
         self.store_headers(x.uid, x.headers.clone());
         return vec![x];
     }
@@ -282,7 +267,7 @@ impl Filter {
         if !original_rpc.headers.contains_key("ferried_data") {
             ferried_data = FerriedData::default();
         } else {
-            match serde_json::from_str(&original_rpc.headers["ferried_data"]) {
+            match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
                 Ok(fd) => { ferried_data = fd; }
                 Err(e) => { print!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
             }
@@ -314,30 +299,12 @@ impl Filter {
                 storage_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
 
                 // 3b. Put baggage into regular rpc
-                match serde_json::to_string(&ferried_data) {
-                    Ok(fd_str) => {
-                        original_rpc.headers.insert("ferried_data".to_string(), fd_str);
-                        return vec!(original_rpc, storage_rpc);
-
-                    }
-                    Err(e) => {
-                        print!("could not serialize baggage {0}\n", e);
-                        return vec![original_rpc];
-                    }
-                }
+                put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+                return vec![original_rpc, storage_rpc];
             }
        }
-       match serde_json::to_string(&ferried_data) {
-            Ok(fd_str) => {
-                original_rpc.headers.insert("ferried_data".to_string(), fd_str);
-                return vec![original_rpc];
-
-            }
-            Err(e) => {
-                print!("could not serialize baggage {0}\n", e);
-                return vec![original_rpc];
-            }
-       }
+       put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+       return vec![original_rpc];
     }
 
     pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -5,8 +5,27 @@ use petgraph::Graph;
 use petgraph::Outgoing;
 use graph_utils::utils;
 use graph_utils::iso::find_mapping_shamir_centralized;
+use serde::Serialize;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+
+#[derive(Debug, Serialize)]
+pub struct FerriedData {
+    set_s: IndexMap<(NodeIndex, NodeIndex), IndexMap<NodeIndex, Option<Vec<(NodeIndex, NodeIndex)>>>>,
+    trace_graph: Graph<(String, IndexMap<String, String>), String>,
+    unassigned_properties: Vec<(String, String, String)>, // entity property value
+}
+
+impl FerriedData {
+    fn default() -> FerriedData {
+        FerriedData {
+            set_s: IndexMap::new(),
+            trace_graph: Graph::new(),
+            unassigned_properties: Vec::new(),
+            
+        }
+    }
+}
 
 // user defined functions:
 {{#each udf_table}}{{{this.func_impl}}}{{/each}}
@@ -19,33 +38,11 @@ pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
 // an Option<String> for every possible envoy value
 
 #[derive(Clone, Debug)]
-pub struct State {
-    pub type_of_state: Option<String>,
-    pub string_data: Option<String>,
-}
-
-impl State {
-    pub fn new() -> State {
-        State {
-            type_of_state: None,
-            string_data: None,
-        }
-    }
-
-    pub fn new_with_str(str_data: String) -> State {
-        State {
-            type_of_state: Some(String::from("String")),
-            string_data: Some(str_data),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
 pub struct Filter {
     pub whoami: Option<String>,
     pub target_graph: Option<Graph<(String, IndexMap<String, String>), String>>,
-    pub filter_state: IndexMap<String, State>,
-    pub envoy_shared_data: IndexMap<String, String>,
+    pub filter_state: IndexMap<String, String>,
+    pub envoy_shared_data: IndexMap<String, String>, // trace ID to stored ferried data as string 
     pub collected_properties: Vec<String>, //properties to collect
 }
 
@@ -63,14 +60,10 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
-        let mut hash = IndexMap::new();
-        for key in string_data.keys() {
-            hash.insert(key.clone(), State::new_with_str(string_data[key].clone()));
-        }
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,
-                                   filter_state: hash,
+                                   filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
                                    collected_properties: vec!({{#each collected_properties}}"{{{this}}}".to_string(), {{/each}} ),
                                }))
@@ -83,64 +76,68 @@ impl Filter {
     }
 
     pub fn set_whoami(&mut self) {
-        let my_node_wrapped = self
-            .filter_state
-            .get("node.metadata.WORKLOAD_NAME");
-        if my_node_wrapped.is_none() {
+        if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
             print!("WARNING: filter was initialized without envoy properties and thus cannot function");
             return;
         }
-        let my_node = my_node_wrapped
-            .unwrap()
-            .string_data
-            .clone()
-            .unwrap();
+        let my_node = self
+            .filter_state["node.metadata.WORKLOAD_NAME"].clone();
         self.whoami = Some(my_node);
         assert!(self.whoami.is_some());
     }
 
     pub fn store_headers(&mut self, x: Rpc) {
-        // store path as well as properties
-        let prop_str = format!("{uid}_properties_path", uid=x.uid);
-        if x.headers.contains_key("properties_path") {
-            if self.envoy_shared_data.contains_key(&prop_str) {
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(",");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(&x.headers["properties_path"]);
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(";");
-                self.envoy_shared_data.get_mut(&prop_str).unwrap().push_str(self.whoami.as_ref().unwrap());
-            }
-            else {
-                // add yourself
-                let mut cur_path = x.headers["properties_path"].clone();
-                cur_path.push_str(";");
-                cur_path.push_str(self.whoami.as_ref().unwrap());
-                self.envoy_shared_data.insert(prop_str, cur_path);
-            }
+        // If you don't have data, nothing to store
+        if !x.headers.contains_key("ferried_data") { 
+            print!("WARNING: no ferried data\n");
         }
-        for key in &self.collected_properties {
-            let prop_str = format!("{uid}_properties_{key}", uid=x.uid, key=key);
-            let prop_key = format!("properties_{key}", key=key);
-            if x.headers.contains_key(&prop_key) {
-                if self.envoy_shared_data.contains_key(&prop_str) { // concatenate with comma if not duplicate
-                    // make lists of properties
-                    let properties_unified = self.envoy_shared_data[&prop_str].clone();
-                    let mut properties : Vec<String> = properties_unified.split(",").map(|s| s.to_string()).collect();
-                    let cur_properties_unified = x.headers[&prop_key].clone();
-                    let mut cur_properties : Vec<String> = cur_properties_unified.split(",").map(|s| s.to_string()).collect();
-
-                    // merge lists and remove duplicates
-                    properties.append(&mut cur_properties);
-                    properties.sort_unstable(); // must sort for dedup to work
-                    properties.dedup();
-
-                    // store result
-                    let property_string_to_store = properties.join(",");
-                    self.envoy_shared_data.insert(prop_str.clone(), property_string_to_store.clone());
-                } else {
-                    self.envoy_shared_data.insert(prop_str.clone(), x.headers[&prop_key].clone());
-                }
-            }
+        // If there is no data stored, you needn't merge - just throw it in
+        if !self.envoy_shared_data.contains_key(x.uid) {
+            self.envoy_shared_data.insert(x.uid, x.headers["ferried_data"]);
         }
+
+        // Else, we merge in 3 parts, for each of the struct values
+        let data: FerriedData = serde_json::from_str(x.headers["ferried_data"]);
+        let stored_data: FerriedData = serde_json::from_str(self.envoy_shared_data[x.uid]);
+
+        // 1. TODO: merge set_s
+
+        // 2. Merge the graphs by becoming another child of root
+
+        let mut root_stored = utils::find_root(&stored_data.trace_graph);
+        let mut root_new = utils::find_root(&data.trace_graph);
+
+        // add nodes
+        for node in data.trace_graph.node_indices() {
+            stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap());
+        }
+
+        // add edges
+        for edge in data.trace_graph.edge_indices() {
+            let edge0_weight = data.trace_graph.node_weight(edge.0).unwrap();
+            let edge1_weight = data.trace_graph.node_weight(edge.1).unwrap();
+            let edge0_in_stored_graph = get_node_with_id(stored_data.trace_graph, edge0_weight);
+            let edge1_in_stored_graph = get_node_with_id(stored_data.trace_graph, edge1_weight);
+            stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, String::new());
+        }
+
+        // add link between roots
+        let root_new_weight = data.trace_graph.node_weight(root_new).unwrap();
+        let root_new_in_stored = get_node_with_id(stored_data.trace_graph, root_new_weight);
+        stored_data.trace_graph.add_edge(
+            root_stored,
+            root_new_in_stored,
+            String::new(),
+        );
+
+        // 3. merge unassigned properties
+        //    these are properties we have collected but are not yet in the graph
+        stored_data.unassigned_properties.append(data.unassigned_properties);
+        stored_data.unassigned_properties.sort_unstable();
+        stored_data.unassigned_properties.dedup();
+
+        self.envoy_shared_data.insert(x.uid, serde_json::to_str(stored_data));
+
     }
 
     pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: IndexMap<String, String>) -> IndexMap<String, String> {

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -145,6 +145,17 @@ impl Filter {
         stored_data.unassigned_properties.sort_unstable();
         stored_data.unassigned_properties.dedup();
 
+        // 3a.  If we have any unassigned properties that should be assigned, now is the time
+        let mut to_delete = Vec::new();
+        for property in &stored_data.unassigned_properties {
+            let node = utils::get_node_with_id(&stored_data.trace_graph, property.0.clone());
+            if node.is_some() {
+                stored_data.trace_graph.node_weight_mut(node.unwrap()).unwrap().1.insert(property.1.clone(), property.2.clone());
+                to_delete.push(property.clone());
+            }
+        }
+        stored_data.unassigned_properties.retain(|x| !to_delete.contains(&x));
+
         match serde_json::to_string(&stored_data) {
             Ok(stored_data_string) => {
                 self.envoy_shared_data.insert(uid, stored_data_string);
@@ -165,25 +176,28 @@ impl Filter {
             match serde_json::from_str(&self.envoy_shared_data[&uid_str]) {
                 Ok(d) => {
                     // 1. TODO:  if needed, do things to set S
-                    // 2. Add yourself as root
-                    let mut data: FerriedData = d;
-                    let mut previous_roots = Vec::new();
-                    for node in data.trace_graph.node_indices() {
-                        if data.trace_graph.neighbors_directed(node, Incoming).count() == 0 {
-                            previous_roots.push(node);
+                    // 2. If response, add yourself as root
+                    if new_rpc_headers["direction"] == "response" {
+                        let mut data: FerriedData = d;
+                        let mut previous_roots = Vec::new();
+                        for node in data.trace_graph.node_indices() {
+                            if data.trace_graph.neighbors_directed(node, Incoming).count() == 0 {
+                                previous_roots.push(node);
+                            }
                         }
-                    }
-                    let me = data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
-
-                    for previous_root in previous_roots {
-                        data.trace_graph.add_edge(me, previous_root, String::new());
-                    }
-                    match serde_json::to_string(&data) {
-                        Ok(stored_data_string) => {
-                            new_rpc_headers.insert("ferried_data".to_string(), stored_data_string);
+                        let me = data.trace_graph.add_node(
+                            (self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+    
+                        for previous_root in previous_roots {
+                            data.trace_graph.add_edge(me, previous_root, String::new());
                         }
-                        Err(e) => {
-                            print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                        match serde_json::to_string(&data) {
+                            Ok(stored_data_string) => {
+                                new_rpc_headers.insert("ferried_data".to_string(), stored_data_string);
+                            }
+                            Err(e) => {
+                                print!("ERROR:  could not translate stored data to json string: {0}\n", e);
+                            }
                         }
                     }
                 }
@@ -269,7 +283,7 @@ impl Filter {
         {{#each udf_blocks}}{{{this}}} {{/each}}
 
         // 3. perform isomorphism and possibly return if root node
-        if self.whoami.as_ref().unwrap() == "{{root_id}}" {
+        if self.whoami.as_ref().unwrap() == root_id {
             let mapping = find_mapping_shamir_centralized(
                 &ferried_data.trace_graph,
                 self.target_graph.as_ref().unwrap(),
@@ -302,6 +316,17 @@ impl Filter {
                         return vec![original_rpc];
                     }
                 }
+            }
+       }
+       match serde_json::to_string(&ferried_data) {
+            Ok(fd_str) => {
+                original_rpc.headers.insert("ferried_data".to_string(), fd_str);
+                return vec![original_rpc];
+
+            }
+            Err(e) => {
+                print!("could not serialize baggage {0}\n", e);
+                return vec![original_rpc];
             }
        }
        return vec![original_rpc];

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -238,7 +238,8 @@ impl CodeGenSimulator {
         // the struct filtering.  This is not the case for trace-level attributes
 
         let if_root_block = format!(
-            "if self.whoami.as_ref().unwrap() == \"{root_id}\" {{\n",
+            "let root_id = \"{root_id}\";
+            if self.whoami.as_ref().unwrap() == root_id {{\n",
             root_id = self.ir.root_id
         );
         self.udf_blocks.push(if_root_block);

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -103,22 +103,11 @@ impl CodeGenSimulator {
     }
 
     fn collect_envoy_property(&mut self, property: String) {
-        let get_prop_block = format!("prop_str = format!(\"{{whoami}}.{{property}}=={{value}}\",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      property=\"{property}\",
-                                                      value=self.filter_state[\"{envoy_property}\"]);
+        let get_prop_block = format!("prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+                                                   \"{property}\".to_string(), 
+                                                   self.filter_state[\"{envoy_property}\"].clone());
                                             ", property=property, envoy_property=self.envoy_properties_to_access_names[&property]);
-        let insert_hdr_block = format!("
-        if x.headers.contains_key(\"properties_{property}\") {{
-            if !x.headers[\"properties_{property}\"].contains(&prop_str) {{ // don't add our properties if they have already been added
-                x.headers.get_mut(&\"properties_{property}\".to_string()).unwrap().push_str(\",\");
-                x.headers.get_mut(&\"properties_{property}\".to_string()).unwrap().push_str(&prop_str);
-            }}
-        }}
-        else {{
-            x.headers.insert(\"properties_{property}\".to_string(), prop_str);
-        }}
-        ", property=property);
+        let insert_hdr_block = "ferried_data.unassigned_properties.push(prop_tuple);".to_string();
         self.request_blocks.push(get_prop_block);
         self.request_blocks.push(insert_hdr_block);
     }
@@ -126,26 +115,18 @@ impl CodeGenSimulator {
     fn collect_udf_property(&mut self, udf_id: String) {
         let get_udf_vals = format!(
             "let my_{id}_value;
-    if x.headers.contains_key(\"properties_path\") {{
-            // TODO:  only create trace graph once and then add to it
-            let graph = self.create_trace_graph(x.clone());
-            let child_iterator = graph.neighbors_directed(
-                utils::get_node_with_id(&graph, self.whoami.as_ref().unwrap().clone()).unwrap(),
+            let child_iterator = ferried_data.trace_graph.neighbors_directed(
+                utils::get_node_with_id(&ferried_data.trace_graph, self.whoami.as_ref().unwrap().clone()).unwrap(),
                 petgraph::Outgoing);
             let mut child_values = Vec::new();
             for child in child_iterator {{
-                child_values.push(graph.node_weight(child).unwrap().1[\"{id}\"].clone());
+                child_values.push(ferried_data.trace_graph.node_weight(child).unwrap().1[\"{id}\"].clone());
             }}
             if child_values.len() == 0 {{
-                my_{id}_value = {leaf_func}(graph);
+                my_{id}_value = {leaf_func}(&ferried_data.trace_graph).to_string();
             }} else {{
-                my_{id}_value = {mid_func}(graph, child_values);
+                my_{id}_value = {mid_func}(&ferried_data.trace_graph, child_values).to_string();
             }}
-         }}
-         else {{
-             print!(\"WARNING: no path header\");
-             return vec!(x);
-         }}
 
         ",
             id = udf_id,
@@ -154,21 +135,15 @@ impl CodeGenSimulator {
         );
         self.udf_blocks.push(get_udf_vals);
 
-        let save_udf_vals = format!("let {udf_id}_str = format!(\"{{whoami}}.{{udf_id}}=={{value}}\",
-                                                      whoami=&self.whoami.as_ref().unwrap(),
-                                                      udf_id=\"properties_{udf_id}\",
-                                                      value=my_{udf_id}_value);
-        if x.headers.contains_key(\"properties_{udf_id}\") {{
-            if !x.headers[\"properties_{udf_id}\"].contains(&{udf_id}_str) {{ // don't add a udf property twice
-                x.headers.get_mut(&\"properties_{udf_id}\".to_string()).unwrap().push_str(\",\");
-                x.headers.get_mut(&\"properties_{udf_id}\".to_string()).unwrap().push_str(&{udf_id}_str);
-            }}
+        let save_udf_vals = format!("
+        let node = utils::get_node_with_id(&ferried_data.trace_graph, self.whoami.as_ref().unwrap().to_string()).unwrap();
+        // if we already have the property, don't add it
+        if !( ferried_data.trace_graph.node_weight(node).unwrap().1.contains_key(\"{id}\") &&
+               ferried_data.trace_graph.node_weight(node).unwrap().1[\"{id}\"] == my_{id}_value ) {{
+           ferried_data.trace_graph.node_weight_mut(node).unwrap().1.insert(
+               \"{id}\".to_string(), my_{id}_value);
         }}
-        else {{
-            x.headers.insert(\"properties_{udf_id}\".to_string(), {udf_id}_str);
-        }}
-
-        ", udf_id=udf_id);
+        ", id=udf_id);
 
         self.udf_blocks.push(save_udf_vals);
     }
@@ -278,9 +253,10 @@ impl CodeGenSimulator {
                 }
                 let trace_filter_block = format!(
                 "
-                let mut trace_prop_str = \"{root_id}.{prop_name}=={value}\".to_string();
-                if x.headers.contains_key(\"properties_{prop_name}\") {{
-                    if !x.headers[\"properties_{prop_name}\"].contains(&trace_prop_str) {{ return vec!(x); }}
+                if ! ( ferried_data.trace_graph.node_weight(\"{root_id}\").unwrap().1.contains(\"prop_name\") &&
+                    ferried_data.trace_graph.node_weight(\"{root_id}\").unwrap().1[\"{prop_name}\"] == \"{value}\" ){{
+                    // TODO:  replace ferried_data
+                    return vec![original_rpc];
                 }}
                 ", root_id=self.ir.root_id, prop_name=prop, value=attr_filter.value);
                 self.udf_blocks.push(trace_filter_block);
@@ -293,12 +269,12 @@ impl CodeGenSimulator {
 
     fn make_storage_rpc_value_from_trace(&mut self, entity: String, property: String) {
         let ret_block = format!(
-        "let trace_node_index = utils::get_node_with_id(&trace_graph, \"{node_id}\".to_string());
+        "let trace_node_index = utils::get_node_with_id(&ferried_data.trace_graph, \"{node_id}\".to_string());
         if trace_node_index.is_none() {{
            print!(\"WARNING Node {node_id} not found\");
-                return vec!(x);
+                return vec![original_rpc];
         }}
-        let mut ret_{prop} = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ \"{prop}\" ];\n
+        let mut ret_{prop} = &ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ \"{prop}\" ];\n
         value = ret_{prop}.to_string();\n",
                 node_id = entity,
                 prop = property
@@ -311,7 +287,7 @@ impl CodeGenSimulator {
         "let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), \"{node_id}\".to_string());
         if node_ptr.is_none() {{
            print!(\"WARNING Node {node_id} not found\");
-                return vec!(x);
+                return vec![original_rpc];
         }}
         let mut trace_node_index = None;
         for map in m {{
@@ -320,11 +296,11 @@ impl CodeGenSimulator {
                 break;
             }}
         }}
-        if trace_node_index == None || !&trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key(\"{prop}\") {{
+        if trace_node_index == None || !&ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key(\"{prop}\") {{
             // we have not yet collected the return property or have a mapping error
-            return vec!(x);
+            return vec![original_rpc];
         }}
-        let mut ret_{prop} = &trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ \"{prop}\" ];\n
+        let mut ret_{prop} = &ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ \"{prop}\" ];\n
         value = ret_{prop}.to_string();\n",
                 node_id = entity,
                 prop = property

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -104,7 +104,7 @@ impl CodeGenSimulator {
 
     fn collect_envoy_property(&mut self, property: String) {
         let get_prop_block = format!(
-            "prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+            "prop_tuple = Property::new(self.whoami.as_ref().unwrap().to_string(),
                                                    \"{property}\".to_string(), 
                                                    self.filter_state[\"{envoy_property}\"].clone());
                                             ",
@@ -268,7 +268,7 @@ impl CodeGenSimulator {
                             return vec![original_rpc];
                         }}
                         Err(e) => {{
-                            print!(\"could not serialize baggage {{0}}\n\", e);
+                            log::error!(\"could not serialize baggage {{0}}\n\", e);
                             return vec![original_rpc];
                         }}
                      }}
@@ -287,7 +287,7 @@ impl CodeGenSimulator {
         let ret_block = format!(
         "let trace_node_index = utils::get_node_with_id(&ferried_data.trace_graph, \"{node_id}\".to_string());
         if trace_node_index.is_none() {{
-           print!(\"WARNING Node {node_id} not found\");
+           log::warn!(\"Node {node_id} not found\");
                 return vec![original_rpc];
         }}
         let mut ret_{prop} = &ferried_data.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ \"{prop}\" ];\n
@@ -302,7 +302,7 @@ impl CodeGenSimulator {
         let ret_block = format!(
         "let node_ptr = utils::get_node_with_id(&self.target_graph.as_ref().unwrap(), \"{node_id}\".to_string());
         if node_ptr.is_none() {{
-           print!(\"WARNING Node {node_id} not found\");
+           log::warn!(\"Node {node_id} not found\");
                 return vec![original_rpc];
         }}
         let mut trace_node_index = None;

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -106,7 +106,7 @@ impl CodeGenSimulator {
         let get_prop_block = format!("prop_str = format!(\"{{whoami}}.{{property}}=={{value}}\",
                                                       whoami=&self.whoami.as_ref().unwrap(),
                                                       property=\"{property}\",
-                                                      value=self.filter_state[\"{envoy_property}\"].string_data.as_ref().unwrap().to_string());
+                                                      value=self.filter_state[\"{envoy_property}\"]);
                                             ", property=property, envoy_property=self.envoy_properties_to_access_names[&property]);
         let insert_hdr_block = format!("
         if x.headers.contains_key(\"properties_{property}\") {{

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -103,10 +103,14 @@ impl CodeGenSimulator {
     }
 
     fn collect_envoy_property(&mut self, property: String) {
-        let get_prop_block = format!("prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
+        let get_prop_block = format!(
+            "prop_tuple = (self.whoami.as_ref().unwrap().to_string(),
                                                    \"{property}\".to_string(), 
                                                    self.filter_state[\"{envoy_property}\"].clone());
-                                            ", property=property, envoy_property=self.envoy_properties_to_access_names[&property]);
+                                            ",
+            property = property,
+            envoy_property = self.envoy_properties_to_access_names[&property]
+        );
         let insert_hdr_block = "ferried_data.unassigned_properties.push(prop_tuple);".to_string();
         self.request_blocks.push(get_prop_block);
         self.request_blocks.push(insert_hdr_block);

--- a/rust_filter/Cargo.toml
+++ b/rust_filter/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["dylib"]
 path = "filter.rs"
 
 [dependencies]
-petgraph = { path = "../petgraph" }
+petgraph = { path = "../petgraph" , features = ["serde-1"] }
 rpc_lib = { path = "../rpc_lib" }
 graph_utils = { path = "../graph_utils" }
 indexmap = { version = "1.6.1", features = ["serde-1"] }


### PR DESCRIPTION
This serializes the baggage into a struct.  One important semantic change is instead of constructing the trace graph each time based on the baggage, we pass along a graph and only add to it on the way.  The rest of the changes aren't conceptually different to what we had before, however there's a lot of changes here, because pretty much everything interacts with the baggage in some way.  I am confident that it works because I have integration tests working for:

get_service_name.cql
height.cql
request_size_avg.cql
request_size_avg_trace_attr.cql

And between those four, I believe we cover all 5 of our language constructs.  However, to get them to work, we need to add
petgraph = { path = "../petgraph" , features = ["serde-1"] }
serde = { version = "1.0", features = ["derive"] }
serde_json = "1.0"

to the filter's Cargo file.

I am hoping that this will be a bit easier to understand and then convert into the real filter - some of the interactions with baggage can now be abstracted away into helper functions.  Please let me know if it's easier to understand, or if there needs to be extra comments in certain places.