### PR TITLE
Use only envoy names

### DIFF
--- a/distributed_filter.rs.handlebars
+++ b/distributed_filter.rs.handlebars
@@ -145,7 +145,7 @@ pub fn collect_envoy_properties(
     filter: &Filter,
     fd: &mut FerriedData,
 ) {
-    let mut prop_tuple;
+    let mut prop_tuple: Property;
     {{#each request_blocks}}{{{this}}} {{/each}}
 }
 

--- a/example_queries/get_service_name.cql
+++ b/example_queries/get_service_name.cql
@@ -1,1 +1,2 @@
-MATCH (a) -[]-> (b {service_name: reviews-v1} )-[]->(c) RETURN a.service_name
+MATCH (a) -[]-> (b {})-[]->(c) WHERE b.node.metadata.WORKLOAD_NAME = 'reviews-v1' RETURN a.request.total_size
+

--- a/example_queries/get_service_name.cql
+++ b/example_queries/get_service_name.cql
@@ -1,2 +1,2 @@
-MATCH (a) -[]-> (b {})-[]->(c) WHERE b.node.metadata.WORKLOAD_NAME = 'reviews-v1' RETURN a.request.total_size
+MATCH (a) -[]-> (b {})-[]->(c) WHERE b.node.metadata.WORKLOAD_NAME = 'reviews-v1' RETURN a.node.metadata.WORKLOAD_NAME
 

--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -40,7 +40,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
+         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "'reviews-v1'".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 
@@ -50,13 +50,13 @@ pub fn collect_envoy_properties(
     filter: &Filter,
     fd: &mut FerriedData,
 ) {
-    let mut prop_tuple;
+    let mut prop_tuple: Property;
     prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "service_name".to_string(), 
+                                                   "node.metadata.WORKLOAD_NAME".to_string(), 
                                                    filter.filter_state["node.metadata.WORKLOAD_NAME"].clone());
                                              fd.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "service_name".to_string(), 
-                                                   filter.filter_state["node.metadata.WORKLOAD_NAME"].clone());
+                                                   "request.total_size".to_string(), 
+                                                   filter.filter_state["request.total_size"].clone());
                                              fd.unassigned_properties.push(prop_tuple); 
 }
 
@@ -93,13 +93,13 @@ pub fn get_value_for_storage(
                 break;
             }
         }
-        if trace_node_index == None || !&fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("service_name") {
+        if trace_node_index == None || !&fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request.total_size") {
             // we have not yet collected the return property or have a mapping error
             return None;
         }
-        let mut ret_service_name = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "service_name" ];
+        let mut ret_request.total_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
 
-        value = ret_service_name.to_string();
+        value = ret_request.total_size.to_string();
  
     return Some(value);
 
@@ -122,7 +122,7 @@ impl Filter {
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "service_name".to_string(), "service_name".to_string(),  ),
+            collected_properties: vec!( "node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
          }))
     }
 
@@ -133,7 +133,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("service_name".to_string(), "service_name".to_string(),  ),
+                                   collected_properties: vec!("node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
                                }))
      }
 

--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -40,7 +40,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
+         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 
@@ -54,9 +54,6 @@ pub fn collect_envoy_properties(
     prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
                                                    "node.metadata.WORKLOAD_NAME".to_string(), 
                                                    filter.filter_state["node.metadata.WORKLOAD_NAME"].clone());
-                                             fd.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "request.total_size".to_string(), 
-                                                   filter.filter_state["request.total_size"].clone());
                                              fd.unassigned_properties.push(prop_tuple); 
 }
 
@@ -93,13 +90,13 @@ pub fn get_value_for_storage(
                 break;
             }
         }
-        if trace_node_index == None || !&fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request.total_size") {
+        if trace_node_index == None || !&fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("node.metadata.WORKLOAD_NAME") {
             // we have not yet collected the return property or have a mapping error
             return None;
         }
-        let mut ret_request.total_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
+        let mut ret_nodemetadataWORKLOAD_NAME = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "node.metadata.WORKLOAD_NAME" ];
 
-        value = ret_request.total_size.to_string();
+        value = ret_nodemetadataWORKLOAD_NAME.to_string();
  
     return Some(value);
 
@@ -122,7 +119,7 @@ impl Filter {
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
+            collected_properties: vec!( "node.metadata.WORKLOAD_NAME".to_string(),  ),
          }))
     }
 
@@ -133,7 +130,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
+                                   collected_properties: vec!("node.metadata.WORKLOAD_NAME".to_string(),  ),
                                }))
      }
 

--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -40,7 +40,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "'reviews-v1'".to_string());
+         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 

--- a/example_queries/height.cql
+++ b/example_queries/height.cql
@@ -1,1 +1,1 @@
-MATCH (a) -[]-> (b {service_name: reviews-v1} )-[]->(c) RETURN a.height
+MATCH (a) -[]-> (b {} )-[]->(c) WHERE b.node.metadata.WORKLOAD_NAME = 'reviews-v1' RETURN a.height

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -61,7 +61,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
+         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -61,7 +61,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
+         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 
@@ -71,9 +71,9 @@ pub fn collect_envoy_properties(
     filter: &Filter,
     fd: &mut FerriedData,
 ) {
-    let mut prop_tuple;
+    let mut prop_tuple: Property;
     prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "service_name".to_string(), 
+                                                   "node.metadata.WORKLOAD_NAME".to_string(), 
                                                    filter.filter_state["node.metadata.WORKLOAD_NAME"].clone());
                                              fd.unassigned_properties.push(prop_tuple); 
 }
@@ -162,7 +162,7 @@ impl Filter {
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "service_name".to_string(), "height".to_string(),  ),
+            collected_properties: vec!( "node.metadata.WORKLOAD_NAME".to_string(), "height".to_string(),  ),
          }))
     }
 
@@ -173,7 +173,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("service_name".to_string(), "height".to_string(),  ),
+                                   collected_properties: vec!("node.metadata.WORKLOAD_NAME".to_string(), "height".to_string(),  ),
                                }))
      }
 

--- a/example_queries/request_size.cql
+++ b/example_queries/request_size.cql
@@ -1,1 +1,1 @@
-MATCH (a) -[]-> (b {service_name: reviews-v1})-[]->(c) RETURN a.request_size
+MATCH (a) -[]-> (b {})-[]->(c) WHERE b.node.metadata.WORKLOAD_NAME = 'reviews-v1' RETURN a.request.total_size

--- a/example_queries/request_size.rs.ref
+++ b/example_queries/request_size.rs.ref
@@ -40,7 +40,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
+         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 
@@ -97,9 +97,9 @@ pub fn get_value_for_storage(
             // we have not yet collected the return property or have a mapping error
             return None;
         }
-        let mut ret_request.total_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
+        let mut ret_requesttotal_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
 
-        value = ret_request.total_size.to_string();
+        value = ret_requesttotal_size.to_string();
  
     return Some(value);
 

--- a/example_queries/request_size.rs.ref
+++ b/example_queries/request_size.rs.ref
@@ -40,7 +40,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
+         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "'reviews-v1'".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 
@@ -50,12 +50,12 @@ pub fn collect_envoy_properties(
     filter: &Filter,
     fd: &mut FerriedData,
 ) {
-    let mut prop_tuple;
+    let mut prop_tuple: Property;
     prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "service_name".to_string(), 
+                                                   "node.metadata.WORKLOAD_NAME".to_string(), 
                                                    filter.filter_state["node.metadata.WORKLOAD_NAME"].clone());
                                              fd.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "request_size".to_string(), 
+                                                   "request.total_size".to_string(), 
                                                    filter.filter_state["request.total_size"].clone());
                                              fd.unassigned_properties.push(prop_tuple); 
 }
@@ -93,13 +93,13 @@ pub fn get_value_for_storage(
                 break;
             }
         }
-        if trace_node_index == None || !&fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request_size") {
+        if trace_node_index == None || !&fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request.total_size") {
             // we have not yet collected the return property or have a mapping error
             return None;
         }
-        let mut ret_request_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
+        let mut ret_request.total_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
 
-        value = ret_request_size.to_string();
+        value = ret_request.total_size.to_string();
  
     return Some(value);
 
@@ -122,7 +122,7 @@ impl Filter {
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "service_name".to_string(), "request_size".to_string(),  ),
+            collected_properties: vec!( "node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
          }))
     }
 
@@ -133,7 +133,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("service_name".to_string(), "request_size".to_string(),  ),
+                                   collected_properties: vec!("node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
                                }))
      }
 

--- a/example_queries/request_size.rs.ref
+++ b/example_queries/request_size.rs.ref
@@ -40,7 +40,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "'reviews-v1'".to_string());
+         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 

--- a/example_queries/request_size_avg.cql
+++ b/example_queries/request_size_avg.cql
@@ -1,1 +1,1 @@
-MATCH (a) -[]-> (b {service_name: reviews-v1})-[]->(c) WHERE trace.request_size = 1 RETURN a.request_size, avg(a.request_size)
+MATCH (a) -[]-> (b {})-[]->(c) WHERE b.node.metadata.WORKLOAD_NAME = 'reviews-v1' AND trace.request.total_size = 1 RETURN a.request.total_size, avg(a.request.total_size)

--- a/example_queries/request_size_avg.rs.ref
+++ b/example_queries/request_size_avg.rs.ref
@@ -40,7 +40,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
+         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "'reviews-v1'".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 
@@ -50,12 +50,12 @@ pub fn collect_envoy_properties(
     filter: &Filter,
     fd: &mut FerriedData,
 ) {
-    let mut prop_tuple;
+    let mut prop_tuple: Property;
     prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "service_name".to_string(), 
+                                                   "node.metadata.WORKLOAD_NAME".to_string(), 
                                                    filter.filter_state["node.metadata.WORKLOAD_NAME"].clone());
                                              fd.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "request_size".to_string(), 
+                                                   "request.total_size".to_string(), 
                                                    filter.filter_state["request.total_size"].clone());
                                              fd.unassigned_properties.push(prop_tuple); 
 }
@@ -67,8 +67,8 @@ pub fn execute_udfs_and_check_trace_lvl_prop(filter: &Filter, fd: &mut FerriedDa
             if filter.whoami.as_ref().unwrap()== root_id {        let mut trace_prop_str : String;
 
                 let root_node = graph_utils::get_node_with_id(&fd.trace_graph, "productpage-v1".to_string()).unwrap();
-                if ! ( fd.trace_graph.node_weight(root_node).unwrap().1.contains_key("request_size") &&
-                    fd.trace_graph.node_weight(root_node).unwrap().1["request_size"] == "1" ){
+                if ! ( fd.trace_graph.node_weight(root_node).unwrap().1.contains_key("request.total_size") &&
+                    fd.trace_graph.node_weight(root_node).unwrap().1["request.total_size"] == "1" ){
                     // TODO:  replace fd
                     match serde_yaml::to_string(&fd) {
                         Ok(fd_str) => {
@@ -110,13 +110,13 @@ pub fn get_value_for_storage(
                 break;
             }
         }
-        if trace_node_index == None || !&fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request_size") {
+        if trace_node_index == None || !&fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request.total_size") {
             // we have not yet collected the return property or have a mapping error
             return None;
         }
-        let mut ret_request_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
+        let mut ret_request.total_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
 
-        value = ret_request_size.to_string();
+        value = ret_request.total_size.to_string();
  
     return Some(value);
 
@@ -139,7 +139,7 @@ impl Filter {
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "service_name".to_string(), "request_size".to_string(),  ),
+            collected_properties: vec!( "node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
          }))
     }
 
@@ -150,7 +150,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("service_name".to_string(), "request_size".to_string(),  ),
+                                   collected_properties: vec!("node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
                                }))
      }
 

--- a/example_queries/request_size_avg.rs.ref
+++ b/example_queries/request_size_avg.rs.ref
@@ -40,7 +40,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
+         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 
@@ -114,9 +114,9 @@ pub fn get_value_for_storage(
             // we have not yet collected the return property or have a mapping error
             return None;
         }
-        let mut ret_request.total_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
+        let mut ret_requesttotal_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
 
-        value = ret_request.total_size.to_string();
+        value = ret_requesttotal_size.to_string();
  
     return Some(value);
 

--- a/example_queries/request_size_avg.rs.ref
+++ b/example_queries/request_size_avg.rs.ref
@@ -40,7 +40,7 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "'reviews-v1'".to_string());
+         b_hashmap.insert(".node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 

--- a/example_queries/request_size_avg_trace_attr.cql
+++ b/example_queries/request_size_avg_trace_attr.cql
@@ -1,1 +1,1 @@
-MATCH (a) -[]-> (b {service_name: reviews-v1})-[]->(c) WHERE trace.request_size = 1 RETURN trace.request_size, avg(trace.request_size)
+MATCH (a) -[]-> (b)-[]->(c) WHERE b.node.metadata.WORKLOAD_NAME = 'reviews-v1' AND trace.request.total_size = 1 RETURN trace.request.total_size, avg(trace.request.total_size)

--- a/example_queries/request_size_avg_trace_attr.rs.ref
+++ b/example_queries/request_size_avg_trace_attr.rs.ref
@@ -34,13 +34,11 @@ pub fn create_target_graph() -> Graph<
     std::string::String,
 > {
      let vertices = vec!(  "a".to_string(), "b".to_string(), "c".to_string(),  );
-         let edges = vec!(   ("a".to_string(), "b".to_string() ),   ("b".to_string(), "c".to_string() ),   );
+         let edges = vec!(   ("a".to_string(), "b".to_string() ),   ("a".to_string(), "c".to_string() ),   );
          let mut ids_to_properties: IndexMap<String, IndexMap<String, String>> = IndexMap::new();
          ids_to_properties.insert("a".to_string(), IndexMap::new());
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
-         let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 
@@ -50,12 +48,12 @@ pub fn collect_envoy_properties(
     filter: &Filter,
     fd: &mut FerriedData,
 ) {
-    let mut prop_tuple;
+    let mut prop_tuple: Property;
     prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "service_name".to_string(), 
+                                                   "node.metadata.WORKLOAD_NAME".to_string(), 
                                                    filter.filter_state["node.metadata.WORKLOAD_NAME"].clone());
                                              fd.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "request_size".to_string(), 
+                                                   "request.total_size".to_string(), 
                                                    filter.filter_state["request.total_size"].clone());
                                              fd.unassigned_properties.push(prop_tuple); 
 }
@@ -67,8 +65,8 @@ pub fn execute_udfs_and_check_trace_lvl_prop(filter: &Filter, fd: &mut FerriedDa
             if filter.whoami.as_ref().unwrap()== root_id {        let mut trace_prop_str : String;
 
                 let root_node = graph_utils::get_node_with_id(&fd.trace_graph, "productpage-v1".to_string()).unwrap();
-                if ! ( fd.trace_graph.node_weight(root_node).unwrap().1.contains_key("request_size") &&
-                    fd.trace_graph.node_weight(root_node).unwrap().1["request_size"] == "1" ){
+                if ! ( fd.trace_graph.node_weight(root_node).unwrap().1.contains_key("request.total_size") &&
+                    fd.trace_graph.node_weight(root_node).unwrap().1["request.total_size"] == "1" ){
                     // TODO:  replace fd
                     match serde_yaml::to_string(&fd) {
                         Ok(fd_str) => {
@@ -103,9 +101,9 @@ pub fn get_value_for_storage(
            log::warn!("Node productpage-v1 not found");
                 return None;
         }
-        let mut ret_request_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request_size" ];
+        let mut ret_request.total_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
 
-        value = ret_request_size.to_string();
+        value = ret_request.total_size.to_string();
  
     return Some(value);
 
@@ -128,7 +126,7 @@ impl Filter {
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "service_name".to_string(), "request_size".to_string(),  ),
+            collected_properties: vec!( "node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
          }))
     }
 
@@ -139,7 +137,7 @@ impl Filter {
                                    target_graph: None,
                                    filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("service_name".to_string(), "request_size".to_string(),  ),
+                                   collected_properties: vec!("node.metadata.WORKLOAD_NAME".to_string(), "request.total_size".to_string(),  ),
                                }))
      }
 

--- a/example_queries/request_size_avg_trace_attr.rs.ref
+++ b/example_queries/request_size_avg_trace_attr.rs.ref
@@ -101,9 +101,9 @@ pub fn get_value_for_storage(
            log::warn!("Node productpage-v1 not found");
                 return None;
         }
-        let mut ret_request.total_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
+        let mut ret_requesttotal_size = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.total_size" ];
 
-        value = ret_request.total_size.to_string();
+        value = ret_requesttotal_size.to_string();
  
     return Some(value);
 

--- a/filter.rs.handlebars
+++ b/filter.rs.handlebars
@@ -41,7 +41,7 @@ pub fn collect_envoy_properties(
     filter: &Filter,
     fd: &mut FerriedData,
 ) {
-    let mut prop_tuple;
+    let mut prop_tuple: Property;
     {{#each request_blocks}}{{{this}}} {{/each}}
 }
 

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -66,9 +66,11 @@ impl CodeGenSimulator {
             to_return.parse_udf(udf);
         }
         to_return
-            .envoy_properties.push("request.total_size".to_string());
-        to_return.
-            envoy_properties.push("node.metadata.WORKLOAD_NAME".to_string());
+            .envoy_properties
+            .push("request.total_size".to_string());
+        to_return
+            .envoy_properties
+            .push("node.metadata.WORKLOAD_NAME".to_string());
         to_return.get_maps();
         to_return.make_struct_filter_blocks();
         to_return.make_attr_filter_blocks();
@@ -168,17 +170,12 @@ impl CodeGenSimulator {
                 // we might have duplicates bc some have preceding periods
                 if !self.udf_table.contains_key(&map_name)
                     && !map_name.is_empty()
-                    && !self
-                        .envoy_properties
-                        .contains(&map_name)
+                    && !self.envoy_properties.contains(&map_name)
                 {
                     panic!("unrecognized UDF {:?}", map_name);
                 }
                 self.collected_properties.push(map_name.clone());
-                if self
-                    .envoy_properties
-                    .contains(&map_name)
-                {
+                if self.envoy_properties.contains(&map_name) {
                     self.collect_envoy_property(map_name);
                 } else {
                     self.collect_udf_property(map_name);
@@ -297,7 +294,7 @@ impl CodeGenSimulator {
 
     fn make_storage_rpc_value_from_trace(&mut self, entity: String, property: String) {
         let mut prop_wo_periods = property.clone();
-        prop_wo_periods.retain(|c| c!='.');
+        prop_wo_periods.retain(|c| c != '.');
         let ret_block = format!(
         "let trace_node_index = graph_utils::get_node_with_id(&fd.trace_graph, \"{node_id}\".to_string());
         if trace_node_index.is_none() {{
@@ -315,7 +312,7 @@ impl CodeGenSimulator {
     }
     fn make_storage_rpc_value_from_target(&mut self, entity: String, property: String) {
         let mut prop_wo_periods = property.clone();
-        prop_wo_periods.retain(|c| c!='.');
+        prop_wo_periods.retain(|c| c != '.');
         let ret_block = format!(
         "let node_ptr = graph_utils::get_node_with_id(target_graph, \"{node_id}\".to_string());
         if node_ptr.is_none() {{
@@ -441,8 +438,9 @@ mod tests {
 
     #[test]
     fn get_codegen_doesnt_throw_error_with_mult_periods() {
-        let result =
-            get_codegen_from_query("MATCH (a) -[]-> (b {})-[]->(c) RETURN a.node.metadata.WORKLOAD_NAME".to_string());
+        let result = get_codegen_from_query(
+            "MATCH (a) -[]-> (b {})-[]->(c) RETURN a.node.metadata.WORKLOAD_NAME".to_string(),
+        );
         assert!(!result.struct_filters.is_empty());
         let _codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());
     }

--- a/rewrite/codegen_simulator.rs
+++ b/rewrite/codegen_simulator.rs
@@ -42,7 +42,7 @@ pub struct CodeGenSimulator {
     udf_blocks: Vec<String>, // code blocks to be used in outgoing responses, to compute UDF before matching
     trace_lvl_prop_blocks: Vec<String>, // code blocks to be used in outgoing responses, to compute UDF before matching
     udf_table: IndexMap<String, Udf>,   // where we store udf implementations
-    envoy_properties_to_access_names: IndexMap<String, String>,
+    envoy_properties: Vec<String>,
     collected_properties: Vec<String>, // all the properties we collect
 }
 
@@ -56,19 +56,19 @@ impl CodeGenSimulator {
             udf_blocks: Vec::new(),
             trace_lvl_prop_blocks: Vec::new(),
             udf_table: IndexMap::default(),
-            envoy_properties_to_access_names: IndexMap::new(),
+            envoy_properties: Vec::new(),
             collected_properties: Vec::new(),
         };
+        for udf in &udfs {
+            log::info!("udf: {:?}\n\n\n\n", udf);
+        }
         for udf in udfs {
             to_return.parse_udf(udf);
         }
         to_return
-            .envoy_properties_to_access_names
-            .insert("request_size".to_string(), "request.total_size".to_string());
-        to_return.envoy_properties_to_access_names.insert(
-            "service_name".to_string(),
-            "node.metadata.WORKLOAD_NAME".to_string(),
-        );
+            .envoy_properties.push("request.total_size".to_string());
+        to_return.
+            envoy_properties.push("node.metadata.WORKLOAD_NAME".to_string());
         to_return.get_maps();
         to_return.make_struct_filter_blocks();
         to_return.make_attr_filter_blocks();
@@ -111,7 +111,7 @@ impl CodeGenSimulator {
                                                    filter.filter_state[\"{envoy_property}\"].clone());
                                             ",
             property = property,
-            envoy_property = self.envoy_properties_to_access_names[&property]
+            envoy_property = property
         );
         let insert_hdr_block = "fd.unassigned_properties.push(prop_tuple);".to_string();
         self.request_blocks.push(get_prop_block);
@@ -169,15 +169,15 @@ impl CodeGenSimulator {
                 if !self.udf_table.contains_key(&map_name)
                     && !map_name.is_empty()
                     && !self
-                        .envoy_properties_to_access_names
-                        .contains_key(&map_name)
+                        .envoy_properties
+                        .contains(&map_name)
                 {
-                    panic!("unrecognized UDF");
+                    panic!("unrecognized UDF {:?}", map_name);
                 }
                 self.collected_properties.push(map_name.clone());
                 if self
-                    .envoy_properties_to_access_names
-                    .contains_key(&map_name)
+                    .envoy_properties
+                    .contains(&map_name)
                 {
                     self.collect_envoy_property(map_name);
                 } else {
@@ -226,19 +226,24 @@ impl CodeGenSimulator {
                 );
                 self.target_blocks.push(get_hashmap);
                 for property_name in struct_filter.properties[node].keys() {
-                    let mut envoy_filtered_property_name = property_name;
-                    // TODO:  more efficient way to do this
-                    for envoy_prop in self.envoy_properties_to_access_names.keys() {
-                        if property_name == envoy_prop {
-                            envoy_filtered_property_name =
-                                &self.envoy_properties_to_access_names[envoy_prop];
-                        }
+                    let mut property_name_without_period = property_name.clone();
+                    if property_name_without_period.starts_with('.') {
+                        property_name_without_period.remove(0);
                     }
                     let fill_in_hashmap = format!("        {node}_hashmap.insert(\"{property_name}\".to_string(), \"{property_value}\".to_string());\n",
                                                    node=node,
-                                                   property_name=envoy_filtered_property_name,
+                                                   property_name=property_name_without_period,
                                                    property_value=struct_filter.properties[node][property_name]);
                     self.target_blocks.push(fill_in_hashmap);
+                }
+                for property_filter in &self.ir.attr_filters {
+                    if property_filter.node != "trace" {
+                        let fill_in_hashmap = format!("        {node}_hashmap.insert(\"{property_name}\".to_string(), \"{property_value}\".to_string());\n",
+                                                       node=property_filter.node,
+                                                       property_name=property_filter.property,
+                                                       property_value=property_filter.value);
+                        self.target_blocks.push(fill_in_hashmap);
+                    }
                 }
             }
             let make_graph = "        return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);\n".to_string();
@@ -423,7 +428,15 @@ mod tests {
     #[test]
     fn get_codegen_doesnt_throw_error() {
         let result =
-            get_codegen_from_query("MATCH (a) -[]-> (b)-[]->(c) RETURN a.count".to_string());
+            get_codegen_from_query("MATCH (a) -[]-> (b {})-[]->(c) RETURN a.count".to_string());
+        assert!(!result.struct_filters.is_empty());
+        let _codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());
+    }
+
+    #[test]
+    fn get_codegen_doesnt_throw_error_with_mult_periods() {
+        let result =
+            get_codegen_from_query("MATCH (a) -[]-> (b {})-[]->(c) RETURN a.node.metadata.WORKLOAD_NAME".to_string());
         assert!(!result.struct_filters.is_empty());
         let _codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());
     }
@@ -431,7 +444,7 @@ mod tests {
     #[test]
     fn get_group_by() {
         let result = get_codegen_from_query(
-            "MATCH (a {service_name: \"productpage-v1\"}) RETURN a.count, agg".to_string(),
+            "MATCH (a {}) WHERE a.node.metadata.WORKLOAD_NAME = 'productpage-v1' RETURN a.count, agg".to_string(),
         );
         assert!(!result.struct_filters.is_empty());
         let _codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());
@@ -443,7 +456,7 @@ mod tests {
     #[test]
     fn test_where() {
         let result = get_codegen_from_query(
-            "MATCH (a) -[]-> (b {service_name: reviews-v1})-[]->(c) WHERE trace.request_size = 1 RETURN a.request_size, avg(a.request_size)".to_string(),
+            "MATCH (a) -[]-> (b)-[]->(c) WHERE b.node.metadata.WORKLOAD_NAME = 'reviews-v1' AND trace.request.total_size = 1 RETURN a.request.total_size, avg(a.request.total_size)".to_string(),
         );
         assert!(!result.struct_filters.is_empty());
         let _codegen = CodeGenSimulator::generate_code_blocks(result, [COUNT.to_string()].to_vec());

--- a/rewrite/to_ir.rs
+++ b/rewrite/to_ir.rs
@@ -419,7 +419,9 @@ mod tests {
         );
         let mut visitor = ReturnVisitor::default();
         let _res = result.accept(&mut visitor);
-        assert!(visitor.return_expr.unwrap().entity == "a");
+        let ret = visitor.return_expr.unwrap();
+        assert!(ret.entity == "a");
+        assert!(ret.property == ".request_size", "property is {:?}", ret.property);
     }
 
     #[test]


### PR DESCRIPTION
Now the compiler uses only envoy names for properties, not the other naming scheme Taegyun came up with.