### PR TITLE
Fix simulator logging

### DIFF
--- a/distributed_filter.rs.handlebars
+++ b/distributed_filter.rs.handlebars
@@ -6,6 +6,15 @@ use utils::graph::graph_utils;
 use utils::graph::iso::find_mapping_shamir_decentralized;
 use serde::{Serialize, Deserialize};
 use utils::graph::serde::Property;
+use log4rs::{
+    append::{
+        console::{ConsoleAppender, Target},
+        file::FileAppender,
+    },
+    config::{Appender, Config, Root},
+    encode::pattern::PatternEncoder,
+    filter::threshold::ThresholdFilter,
+};
 
 extern crate serde_yaml;
 
@@ -115,6 +124,42 @@ impl FerriedData {
     }
 }
 
+fn log_setup() {
+    // Build a stderr logger.
+    let stderr = ConsoleAppender::builder()
+        .encoder(Box::new(PatternEncoder::new("{h({l})}: {m}\n")))
+        .target(Target::Stderr)
+        .build();
+    // Logging to log file.
+    let logfile = FileAppender::builder()
+        // Pattern: https://docs.rs/log4rs/*/log4rs/encode/pattern/index.html
+        .encoder(Box::new(PatternEncoder::new("{l}: {m}\n")))
+        .append(false)
+        .build("sim.log")
+        .unwrap();
+    // Log Trace level output to file where trace is the default level
+    // and the programmatically specified level to stderr.
+    let config = Config::builder()
+        .appender(Appender::builder().build("logfile", Box::new(logfile)))
+        .appender(
+            Appender::builder()
+                .filter(Box::new(ThresholdFilter::new(log::LevelFilter::Info)))
+                .build("stderr", Box::new(stderr)),
+        )
+        .build(
+            Root::builder()
+                .appender("logfile")
+                .appender("stderr")
+                .build(log::LevelFilter::Trace),
+        )
+        .unwrap();
+    // Use this to change log levels at runtime.
+    // This means you can change the default log level to trace
+    // if you are trying to debug an issue and need more logs on then turn it off
+    // once you are done.
+    let _handle = log4rs::init_config(config);
+}
+
 fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
     match serde_yaml::to_string(fd) {
         Ok(stored_data_string) => {
@@ -188,6 +233,7 @@ pub struct Filter {
 impl Filter {
     #[no_mangle]
     pub fn new() -> *mut Filter {
+        log_setup();
          Box::into_raw(Box::new(Filter {
             whoami: None,
             target_graph: None,
@@ -199,6 +245,7 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
+        log_setup();
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,

--- a/example_queries/get_service_name.rs.ref
+++ b/example_queries/get_service_name.rs.ref
@@ -6,11 +6,56 @@ use utils::graph::graph_utils;
 use utils::graph::iso::find_mapping_shamir_centralized;
 use utils::graph::serde::FerriedData;
 use utils::graph::serde::Property;
+use log4rs::{
+    append::{
+        console::{ConsoleAppender, Target},
+        file::FileAppender,
+    },
+    config::{Appender, Config, Root},
+    encode::pattern::PatternEncoder,
+    filter::threshold::ThresholdFilter,
+};
 
 use serde::{Serialize, Deserialize};
 extern crate serde_yaml;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+fn log_setup() {                                                                
+    // Build a stderr logger.                                                   
+    let stderr = ConsoleAppender::builder()                                     
+        .encoder(Box::new(PatternEncoder::new("{h({l})}: {m}\n")))              
+        .target(Target::Stderr)                                                 
+        .build();                                                               
+    // Logging to log file.                                                     
+    let logfile = FileAppender::builder()                                       
+        // Pattern: https://docs.rs/log4rs/*/log4rs/encode/pattern/index.html   
+        .encoder(Box::new(PatternEncoder::new("{l}: {m}\n")))                   
+        .append(false)                                                          
+        .build("sim.log")                                                       
+        .unwrap();                                                              
+    // Log Trace level output to file where trace is the default level          
+    // and the programmatically specified level to stderr.                      
+    let config = Config::builder()                                              
+        .appender(Appender::builder().build("logfile", Box::new(logfile)))      
+        .appender(                                                              
+            Appender::builder()                                                 
+                .filter(Box::new(ThresholdFilter::new(log::LevelFilter::Info))) 
+                .build("stderr", Box::new(stderr)),                             
+        )                                                                       
+        .build(                                                                 
+            Root::builder()                                                     
+                .appender("logfile")                                            
+                .appender("stderr")                                             
+                .build(log::LevelFilter::Trace),                                
+        )                                                                       
+        .unwrap();                                                              
+    // Use this to change log levels at runtime.                                
+    // This means you can change the default log level to trace                 
+    // if you are trying to debug an issue and need more logs on then turn it off
+    // once you are done.                                                       
+    let _handle = log4rs::init_config(config);                                  
+}    
+
 
 fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
     match serde_yaml::to_string(fd) {
@@ -114,6 +159,7 @@ pub struct Filter {
 impl Filter {
     #[no_mangle]
     pub fn new() -> *mut Filter {
+         log_setup();
          Box::into_raw(Box::new(Filter {
             whoami: None,
             target_graph: None,
@@ -125,6 +171,7 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
+        log_setup();
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,

--- a/example_queries/height.cql
+++ b/example_queries/height.cql
@@ -1,1 +1,1 @@
-MATCH (a) -[]-> (b {} )-[]->(c) WHERE b.node.metadata.WORKLOAD_NAME = 'reviews-v1' RETURN a.height
+MATCH (a) -[]-> (b {} )-[]->(c) RETURN a.height

--- a/example_queries/height.rs.ref
+++ b/example_queries/height.rs.ref
@@ -6,11 +6,56 @@ use utils::graph::graph_utils;
 use utils::graph::iso::find_mapping_shamir_centralized;
 use utils::graph::serde::FerriedData;
 use utils::graph::serde::Property;
+use log4rs::{
+    append::{
+        console::{ConsoleAppender, Target},
+        file::FileAppender,
+    },
+    config::{Appender, Config, Root},
+    encode::pattern::PatternEncoder,
+    filter::threshold::ThresholdFilter,
+};
 
 use serde::{Serialize, Deserialize};
 extern crate serde_yaml;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+fn log_setup() {                                                                
+    // Build a stderr logger.                                                   
+    let stderr = ConsoleAppender::builder()                                     
+        .encoder(Box::new(PatternEncoder::new("{h({l})}: {m}\n")))              
+        .target(Target::Stderr)                                                 
+        .build();                                                               
+    // Logging to log file.                                                     
+    let logfile = FileAppender::builder()                                       
+        // Pattern: https://docs.rs/log4rs/*/log4rs/encode/pattern/index.html   
+        .encoder(Box::new(PatternEncoder::new("{l}: {m}\n")))                   
+        .append(false)                                                          
+        .build("sim.log")                                                       
+        .unwrap();                                                              
+    // Log Trace level output to file where trace is the default level          
+    // and the programmatically specified level to stderr.                      
+    let config = Config::builder()                                              
+        .appender(Appender::builder().build("logfile", Box::new(logfile)))      
+        .appender(                                                              
+            Appender::builder()                                                 
+                .filter(Box::new(ThresholdFilter::new(log::LevelFilter::Info))) 
+                .build("stderr", Box::new(stderr)),                             
+        )                                                                       
+        .build(                                                                 
+            Root::builder()                                                     
+                .appender("logfile")                                            
+                .appender("stderr")                                             
+                .build(log::LevelFilter::Trace),                                
+        )                                                                       
+        .unwrap();                                                              
+    // Use this to change log levels at runtime.                                
+    // This means you can change the default log level to trace                 
+    // if you are trying to debug an issue and need more logs on then turn it off
+    // once you are done.                                                       
+    let _handle = log4rs::init_config(config);                                  
+}    
+
 
 fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
     match serde_yaml::to_string(fd) {
@@ -61,7 +106,6 @@ pub fn create_target_graph() -> Graph<
          ids_to_properties.insert("b".to_string(), IndexMap::new());
          ids_to_properties.insert("c".to_string(), IndexMap::new());
          let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-         b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
          return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
  
 
@@ -72,10 +116,7 @@ pub fn collect_envoy_properties(
     fd: &mut FerriedData,
 ) {
     let mut prop_tuple: Property;
-    prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
-                                                   "node.metadata.WORKLOAD_NAME".to_string(), 
-                                                   filter.filter_state["node.metadata.WORKLOAD_NAME"].clone());
-                                             fd.unassigned_properties.push(prop_tuple); 
+    
 }
 
 pub fn execute_udfs_and_check_trace_lvl_prop(filter: &Filter, fd: &mut FerriedData) -> bool{
@@ -157,23 +198,25 @@ pub struct Filter {
 impl Filter {
     #[no_mangle]
     pub fn new() -> *mut Filter {
+         log_setup();
          Box::into_raw(Box::new(Filter {
             whoami: None,
             target_graph: None,
             filter_state: IndexMap::new(),
             envoy_shared_data: IndexMap::<String, String>::new(),
-            collected_properties: vec!( "node.metadata.WORKLOAD_NAME".to_string(), "height".to_string(),  ),
+            collected_properties: vec!( "height".to_string(),  ),
          }))
     }
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
+        log_setup();
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,
                                    filter_state: string_data,
                                    envoy_shared_data: IndexMap::new(),
-                                   collected_properties: vec!("node.metadata.WORKLOAD_NAME".to_string(), "height".to_string(),  ),
+                                   collected_properties: vec!("height".to_string(),  ),
                                }))
      }
 

--- a/example_queries/request_size.rs.ref
+++ b/example_queries/request_size.rs.ref
@@ -6,11 +6,56 @@ use utils::graph::graph_utils;
 use utils::graph::iso::find_mapping_shamir_centralized;
 use utils::graph::serde::FerriedData;
 use utils::graph::serde::Property;
+use log4rs::{
+    append::{
+        console::{ConsoleAppender, Target},
+        file::FileAppender,
+    },
+    config::{Appender, Config, Root},
+    encode::pattern::PatternEncoder,
+    filter::threshold::ThresholdFilter,
+};
 
 use serde::{Serialize, Deserialize};
 extern crate serde_yaml;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+fn log_setup() {                                                                
+    // Build a stderr logger.                                                   
+    let stderr = ConsoleAppender::builder()                                     
+        .encoder(Box::new(PatternEncoder::new("{h({l})}: {m}\n")))              
+        .target(Target::Stderr)                                                 
+        .build();                                                               
+    // Logging to log file.                                                     
+    let logfile = FileAppender::builder()                                       
+        // Pattern: https://docs.rs/log4rs/*/log4rs/encode/pattern/index.html   
+        .encoder(Box::new(PatternEncoder::new("{l}: {m}\n")))                   
+        .append(false)                                                          
+        .build("sim.log")                                                       
+        .unwrap();                                                              
+    // Log Trace level output to file where trace is the default level          
+    // and the programmatically specified level to stderr.                      
+    let config = Config::builder()                                              
+        .appender(Appender::builder().build("logfile", Box::new(logfile)))      
+        .appender(                                                              
+            Appender::builder()                                                 
+                .filter(Box::new(ThresholdFilter::new(log::LevelFilter::Info))) 
+                .build("stderr", Box::new(stderr)),                             
+        )                                                                       
+        .build(                                                                 
+            Root::builder()                                                     
+                .appender("logfile")                                            
+                .appender("stderr")                                             
+                .build(log::LevelFilter::Trace),                                
+        )                                                                       
+        .unwrap();                                                              
+    // Use this to change log levels at runtime.                                
+    // This means you can change the default log level to trace                 
+    // if you are trying to debug an issue and need more logs on then turn it off
+    // once you are done.                                                       
+    let _handle = log4rs::init_config(config);                                  
+}    
+
 
 fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
     match serde_yaml::to_string(fd) {
@@ -117,6 +162,7 @@ pub struct Filter {
 impl Filter {
     #[no_mangle]
     pub fn new() -> *mut Filter {
+         log_setup();
          Box::into_raw(Box::new(Filter {
             whoami: None,
             target_graph: None,
@@ -128,6 +174,7 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
+        log_setup();
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,

--- a/example_queries/request_size_avg.rs.ref
+++ b/example_queries/request_size_avg.rs.ref
@@ -6,11 +6,56 @@ use utils::graph::graph_utils;
 use utils::graph::iso::find_mapping_shamir_centralized;
 use utils::graph::serde::FerriedData;
 use utils::graph::serde::Property;
+use log4rs::{
+    append::{
+        console::{ConsoleAppender, Target},
+        file::FileAppender,
+    },
+    config::{Appender, Config, Root},
+    encode::pattern::PatternEncoder,
+    filter::threshold::ThresholdFilter,
+};
 
 use serde::{Serialize, Deserialize};
 extern crate serde_yaml;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+fn log_setup() {                                                                
+    // Build a stderr logger.                                                   
+    let stderr = ConsoleAppender::builder()                                     
+        .encoder(Box::new(PatternEncoder::new("{h({l})}: {m}\n")))              
+        .target(Target::Stderr)                                                 
+        .build();                                                               
+    // Logging to log file.                                                     
+    let logfile = FileAppender::builder()                                       
+        // Pattern: https://docs.rs/log4rs/*/log4rs/encode/pattern/index.html   
+        .encoder(Box::new(PatternEncoder::new("{l}: {m}\n")))                   
+        .append(false)                                                          
+        .build("sim.log")                                                       
+        .unwrap();                                                              
+    // Log Trace level output to file where trace is the default level          
+    // and the programmatically specified level to stderr.                      
+    let config = Config::builder()                                              
+        .appender(Appender::builder().build("logfile", Box::new(logfile)))      
+        .appender(                                                              
+            Appender::builder()                                                 
+                .filter(Box::new(ThresholdFilter::new(log::LevelFilter::Info))) 
+                .build("stderr", Box::new(stderr)),                             
+        )                                                                       
+        .build(                                                                 
+            Root::builder()                                                     
+                .appender("logfile")                                            
+                .appender("stderr")                                             
+                .build(log::LevelFilter::Trace),                                
+        )                                                                       
+        .unwrap();                                                              
+    // Use this to change log levels at runtime.                                
+    // This means you can change the default log level to trace                 
+    // if you are trying to debug an issue and need more logs on then turn it off
+    // once you are done.                                                       
+    let _handle = log4rs::init_config(config);                                  
+}    
+
 
 fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
     match serde_yaml::to_string(fd) {
@@ -134,6 +179,7 @@ pub struct Filter {
 impl Filter {
     #[no_mangle]
     pub fn new() -> *mut Filter {
+         log_setup();
          Box::into_raw(Box::new(Filter {
             whoami: None,
             target_graph: None,
@@ -145,6 +191,7 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
+        log_setup();
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,

--- a/example_queries/request_size_avg_trace_attr.rs.ref
+++ b/example_queries/request_size_avg_trace_attr.rs.ref
@@ -6,11 +6,56 @@ use utils::graph::graph_utils;
 use utils::graph::iso::find_mapping_shamir_centralized;
 use utils::graph::serde::FerriedData;
 use utils::graph::serde::Property;
+use log4rs::{
+    append::{
+        console::{ConsoleAppender, Target},
+        file::FileAppender,
+    },
+    config::{Appender, Config, Root},
+    encode::pattern::PatternEncoder,
+    filter::threshold::ThresholdFilter,
+};
 
 use serde::{Serialize, Deserialize};
 extern crate serde_yaml;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+fn log_setup() {                                                                
+    // Build a stderr logger.                                                   
+    let stderr = ConsoleAppender::builder()                                     
+        .encoder(Box::new(PatternEncoder::new("{h({l})}: {m}\n")))              
+        .target(Target::Stderr)                                                 
+        .build();                                                               
+    // Logging to log file.                                                     
+    let logfile = FileAppender::builder()                                       
+        // Pattern: https://docs.rs/log4rs/*/log4rs/encode/pattern/index.html   
+        .encoder(Box::new(PatternEncoder::new("{l}: {m}\n")))                   
+        .append(false)                                                          
+        .build("sim.log")                                                       
+        .unwrap();                                                              
+    // Log Trace level output to file where trace is the default level          
+    // and the programmatically specified level to stderr.                      
+    let config = Config::builder()                                              
+        .appender(Appender::builder().build("logfile", Box::new(logfile)))      
+        .appender(                                                              
+            Appender::builder()                                                 
+                .filter(Box::new(ThresholdFilter::new(log::LevelFilter::Info))) 
+                .build("stderr", Box::new(stderr)),                             
+        )                                                                       
+        .build(                                                                 
+            Root::builder()                                                     
+                .appender("logfile")                                            
+                .appender("stderr")                                             
+                .build(log::LevelFilter::Trace),                                
+        )                                                                       
+        .unwrap();                                                              
+    // Use this to change log levels at runtime.                                
+    // This means you can change the default log level to trace                 
+    // if you are trying to debug an issue and need more logs on then turn it off
+    // once you are done.                                                       
+    let _handle = log4rs::init_config(config);                                  
+}    
+
 
 fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
     match serde_yaml::to_string(fd) {
@@ -121,6 +166,7 @@ pub struct Filter {
 impl Filter {
     #[no_mangle]
     pub fn new() -> *mut Filter {
+         log_setup();
          Box::into_raw(Box::new(Filter {
             whoami: None,
             target_graph: None,
@@ -132,6 +178,7 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
+        log_setup();
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,

--- a/simulation_filter.rs.handlebars
+++ b/simulation_filter.rs.handlebars
@@ -6,11 +6,56 @@ use utils::graph::graph_utils;
 use utils::graph::iso::find_mapping_shamir_centralized;
 use utils::graph::serde::FerriedData;
 use utils::graph::serde::Property;
+use log4rs::{
+    append::{
+        console::{ConsoleAppender, Target},
+        file::FileAppender,
+    },
+    config::{Appender, Config, Root},
+    encode::pattern::PatternEncoder,
+    filter::threshold::ThresholdFilter,
+};
 
 use serde::{Serialize, Deserialize};
 extern crate serde_yaml;
 
 pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+fn log_setup() {                                                                
+    // Build a stderr logger.                                                   
+    let stderr = ConsoleAppender::builder()                                     
+        .encoder(Box::new(PatternEncoder::new("{h({l})}: {m}\n")))              
+        .target(Target::Stderr)                                                 
+        .build();                                                               
+    // Logging to log file.                                                     
+    let logfile = FileAppender::builder()                                       
+        // Pattern: https://docs.rs/log4rs/*/log4rs/encode/pattern/index.html   
+        .encoder(Box::new(PatternEncoder::new("{l}: {m}\n")))                   
+        .append(false)                                                          
+        .build("sim.log")                                                       
+        .unwrap();                                                              
+    // Log Trace level output to file where trace is the default level          
+    // and the programmatically specified level to stderr.                      
+    let config = Config::builder()                                              
+        .appender(Appender::builder().build("logfile", Box::new(logfile)))      
+        .appender(                                                              
+            Appender::builder()                                                 
+                .filter(Box::new(ThresholdFilter::new(log::LevelFilter::Info))) 
+                .build("stderr", Box::new(stderr)),                             
+        )                                                                       
+        .build(                                                                 
+            Root::builder()                                                     
+                .appender("logfile")                                            
+                .appender("stderr")                                             
+                .build(log::LevelFilter::Trace),                                
+        )                                                                       
+        .unwrap();                                                              
+    // Use this to change log levels at runtime.                                
+    // This means you can change the default log level to trace                 
+    // if you are trying to debug an issue and need more logs on then turn it off
+    // once you are done.                                                       
+    let _handle = log4rs::init_config(config);                                  
+}    
+
 
 fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
     match serde_yaml::to_string(fd) {
@@ -81,6 +126,7 @@ pub struct Filter {
 impl Filter {
     #[no_mangle]
     pub fn new() -> *mut Filter {
+         log_setup();
          Box::into_raw(Box::new(Filter {
             whoami: None,
             target_graph: None,
@@ -92,6 +138,7 @@ impl Filter {
 
     #[no_mangle]
     pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
+        log_setup();
         Box::into_raw(Box::new(Filter {
                                    whoami: None,
                                    target_graph: None,


### PR DESCRIPTION
This uses the same setup as is in tracing_sim/example_envs/bookinfo to make sure logging from the filter shows up in the simulator.  I also changed height to not have any attribute filters, because we don't have any queries like that and I would like the queries to be a bit more diverse so we can catch errors like the (a)->(b)->(c) does not detect proper edges one.