### PR TITLE
Small fixes for height.

### DIFF
--- a/example_queries/envoy/get_service_name.rs.ref
+++ b/example_queries/envoy/get_service_name.rs.ref
@@ -34,7 +34,7 @@ pub fn collect_envoy_properties(
     fd: &mut FerriedData,
 ) -> Result<(), ()> {
     let mut prop_tuple: Property;
-    let mut prop_tuple_wrapped;
+    let mut prop_tuple_wrapped: Option<Property>;
     prop_tuple_wrapped = fetch_property(&http_headers.workload_name,
                                         &"node.metadata.WORKLOAD_NAME".split(".").collect(),
                                         http_headers);

--- a/example_queries/envoy/request_size.rs.ref
+++ b/example_queries/envoy/request_size.rs.ref
@@ -34,7 +34,7 @@ pub fn collect_envoy_properties(
     fd: &mut FerriedData,
 ) -> Result<(), ()> {
     let mut prop_tuple: Property;
-    let mut prop_tuple_wrapped;
+    let mut prop_tuple_wrapped: Option<Property>;
     prop_tuple_wrapped = fetch_property(&http_headers.workload_name,
                                         &"node.metadata.WORKLOAD_NAME".split(".").collect(),
                                         http_headers);

--- a/src/codegen_envoy.rs
+++ b/src/codegen_envoy.rs
@@ -401,22 +401,22 @@ mod tests {
     use antlr_rust::InputStream;
 
     static COUNT: &str = "
-        // udf_type: Scalar
-	// leaf_func: leaf
-	// mid_func: mid
-	// id: count
+    // udf_type: Scalar
+    // leaf_func: leaf
+    // mid_func: mid
+    // id: count
 
-	use petgraph::Graph;
+    use petgraph::Graph;
 
-	struct ServiceName {
-	    fn leaf(my_node: String, graph: Graph) {
-		return 0;
-	    }
+    struct ServiceName {
+        fn leaf(my_node: String, graph: Graph) {
+        return 0;
+        }
 
-	    fn mid(my_node: String, graph: Graph) {
-		return 1;
-	    }
-	}
+        fn mid(my_node: String, graph: Graph) {
+        return 1;
+        }
+    }
     ";
     fn get_codegen_from_query(input: String) -> VisitorResults {
         let tf = CommonTokenFactory::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn main() {
 
     let bin_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let template_dir = bin_dir.join("templates");
-    let def_filter_dir = bin_dir.join("rs_filter/filter.rs");
+    let def_filter_dir = bin_dir.join("filter_envoy/filter.rs");
     let compile_vals = ["sim", "envoy"];
     let matches = App::new("Dynamic Tracing")
         .arg(

--- a/templates/envoy_filter.rs.handlebars
+++ b/templates/envoy_filter.rs.handlebars
@@ -27,7 +27,7 @@ pub fn collect_envoy_properties(
     fd: &mut FerriedData,
 ) -> Result<(), ()> {
     let mut prop_tuple: Property;
-    let mut prop_tuple_wrapped;
+    let mut prop_tuple_wrapped: Option<Property>;
     {{#each request_blocks}}{{{this}}}{{/each}}
     return Ok(());
 }


### PR DESCRIPTION
Small fixes to make height work

`MATCH (a) -[]-> (b {} )-[]->(c) RETURN a.height`
should be 
`MATCH (a) -[]-> (b {} )-[]->(c) RETURN height(a)`
to be consistent since height is not an inherent property. 
Will work on this over the next week. 
