### PR TITLE
Typing properties

### DIFF
--- a/distributed_filter_envoy/filter_base.rs
+++ b/distributed_filter_envoy/filter_base.rs
@@ -208,41 +208,6 @@ fn fetch_data_from_headers(ctx: &HttpHeaders, request_type: HttpType) -> Ferried
     return FerriedData::default();
 }
 
-pub fn fetch_property(
-    node_name: &str,
-    prop_query: &Vec<&str>,
-    ctx: &HttpHeaders,
-) -> Result<Property, String> {
-    // Insert properties to collect
-    let prop_tuple;
-    // Seems like we need a copy here, a little bit annoying
-    let property = ctx
-        .get_property(prop_query.to_vec())
-        .ok_or_else(|| format!("Failed to retrieve property {:?}.", prop_query))?;
-    let property_str = match std::str::from_utf8(&property) {
-        Ok(property_str_) => property_str_.to_string(),
-        Err(_err) => {
-            // Some values are stored as integers
-            // Try this, but we may get nonsense.
-            // TODO: Explicit types and casting
-            // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
-            let mut byte_array = [0u8; 8];
-            for (place, element) in byte_array.iter_mut().zip(property.iter()) {
-                *place = *element;
-            }
-            let int_val = i64::from_ne_bytes(byte_array);
-            int_val.to_string()
-        }
-    };
-    //TODO: Adjust the format of this property
-    prop_tuple = Property::new(
-        node_name.to_string(),
-        join_str(prop_query),
-        property_str.clone(),
-    );
-    return Ok(prop_tuple);
-}
-
 fn get_shared_data(trace_id: &str, ctx: &HttpHeaders) -> Option<FerriedData> {
     let mut stored_data: FerriedData = FerriedData::default();
     if let (Some(data), _) = ctx.get_shared_data(&trace_id) {

--- a/example_queries/connection_id.cql
+++ b/example_queries/connection_id.cql
@@ -1,0 +1,1 @@
+MATCH (a)-[]->(b)-[]->(c) WHERE c.node.metadata.WORKLOAD_NAME = 'ratings-v1' RETURN a.connection.id

--- a/example_queries/envoy/get_service_name.rs.ref
+++ b/example_queries/envoy/get_service_name.rs.ref
@@ -1,7 +1,8 @@
 // ---------------------- Generated Functions ----------------------------
 
-use super::filter_base::fetch_property;
 use super::filter_base::HttpHeaders;
+use super::filter_base::join_str;
+use proxy_wasm::traits::Context;
 use indexmap::IndexMap;
 use petgraph::graph::{Graph, NodeIndex};
 use utils::graph::graph_utils::generate_target_graph;
@@ -35,14 +36,40 @@ pub fn collect_envoy_properties(
     http_headers: &HttpHeaders,
     fd: &mut FerriedData,
 ) -> Result<(), String> {
-    let prop_tuple = fetch_property(&http_headers.workload_name,
-                                        &vec!["node", "metadata", "WORKLOAD_NAME", ],
-                                        http_headers)?;
-    fd.unassigned_properties.push(prop_tuple);
-    let prop_tuple = fetch_property(&http_headers.workload_name,
-                                        &vec!["node", "metadata", "WORKLOAD_NAME", ],
-                                        http_headers)?;
-    fd.unassigned_properties.push(prop_tuple);
+    
+             let property = http_headers
+                            .get_property(vec!["node", "metadata", "WORKLOAD_NAME", ].to_vec())
+                            .ok_or_else(|| format!("Failed to retrieve property node.metadata.WORKLOAD_NAME."))?;
+            
+    
+                     let property_str = match std::str::from_utf8(&property) {
+                        Ok(property_str_) => {
+                            fd.unassigned_properties.push(Property::new(
+                                http_headers.workload_name.to_string(), 
+                                join_str(&vec!["node", "metadata", "WORKLOAD_NAME", ]),
+                                property_str_.to_string()
+                            ));
+                        }
+                        Err(e) => { return Err(e.to_string()); }
+                    };
+                
+    
+             let property = http_headers
+                            .get_property(vec!["node", "metadata", "WORKLOAD_NAME", ].to_vec())
+                            .ok_or_else(|| format!("Failed to retrieve property node.metadata.WORKLOAD_NAME."))?;
+            
+    
+                     let property_str = match std::str::from_utf8(&property) {
+                        Ok(property_str_) => {
+                            fd.unassigned_properties.push(Property::new(
+                                http_headers.workload_name.to_string(), 
+                                join_str(&vec!["node", "metadata", "WORKLOAD_NAME", ]),
+                                property_str_.to_string()
+                            ));
+                        }
+                        Err(e) => { return Err(e.to_string()); }
+                    };
+                
     
     return Ok(());
 }

--- a/example_queries/envoy/height.rs.ref
+++ b/example_queries/envoy/height.rs.ref
@@ -1,7 +1,8 @@
 // ---------------------- Generated Functions ----------------------------
 
-use super::filter_base::fetch_property;
 use super::filter_base::HttpHeaders;
+use super::filter_base::join_str;
+use proxy_wasm::traits::Context;
 use indexmap::IndexMap;
 use petgraph::graph::{Graph, NodeIndex};
 use utils::graph::graph_utils::generate_target_graph;

--- a/example_queries/envoy/height_avg.rs.ref
+++ b/example_queries/envoy/height_avg.rs.ref
@@ -1,7 +1,8 @@
 // ---------------------- Generated Functions ----------------------------
 
-use super::filter_base::fetch_property;
 use super::filter_base::HttpHeaders;
+use super::filter_base::join_str;
+use proxy_wasm::traits::Context;
 use indexmap::IndexMap;
 use petgraph::graph::{Graph, NodeIndex};
 use utils::graph::graph_utils::generate_target_graph;
@@ -56,10 +57,23 @@ pub fn collect_envoy_properties(
     http_headers: &HttpHeaders,
     fd: &mut FerriedData,
 ) -> Result<(), String> {
-    let prop_tuple = fetch_property(&http_headers.workload_name,
-                                        &vec!["node", "metadata", "WORKLOAD_NAME", ],
-                                        http_headers)?;
-    fd.unassigned_properties.push(prop_tuple);
+    
+             let property = http_headers
+                            .get_property(vec!["node", "metadata", "WORKLOAD_NAME", ].to_vec())
+                            .ok_or_else(|| format!("Failed to retrieve property node.metadata.WORKLOAD_NAME."))?;
+            
+    
+                     let property_str = match std::str::from_utf8(&property) {
+                        Ok(property_str_) => {
+                            fd.unassigned_properties.push(Property::new(
+                                http_headers.workload_name.to_string(), 
+                                join_str(&vec!["node", "metadata", "WORKLOAD_NAME", ]),
+                                property_str_.to_string()
+                            ));
+                        }
+                        Err(e) => { return Err(e.to_string()); }
+                    };
+                
     
     return Ok(());
 }

--- a/example_queries/envoy/request_size.rs.ref
+++ b/example_queries/envoy/request_size.rs.ref
@@ -1,7 +1,8 @@
 // ---------------------- Generated Functions ----------------------------
 
-use super::filter_base::fetch_property;
 use super::filter_base::HttpHeaders;
+use super::filter_base::join_str;
+use proxy_wasm::traits::Context;
 use indexmap::IndexMap;
 use petgraph::graph::{Graph, NodeIndex};
 use utils::graph::graph_utils::generate_target_graph;
@@ -35,14 +36,39 @@ pub fn collect_envoy_properties(
     http_headers: &HttpHeaders,
     fd: &mut FerriedData,
 ) -> Result<(), String> {
-    let prop_tuple = fetch_property(&http_headers.workload_name,
-                                        &vec!["node", "metadata", "WORKLOAD_NAME", ],
-                                        http_headers)?;
-    fd.unassigned_properties.push(prop_tuple);
-    let prop_tuple = fetch_property(&http_headers.workload_name,
-                                        &vec!["request", "total_size", ],
-                                        http_headers)?;
-    fd.unassigned_properties.push(prop_tuple);
+    
+             let property = http_headers
+                            .get_property(vec!["node", "metadata", "WORKLOAD_NAME", ].to_vec())
+                            .ok_or_else(|| format!("Failed to retrieve property node.metadata.WORKLOAD_NAME."))?;
+            
+    
+                     let property_str = match std::str::from_utf8(&property) {
+                        Ok(property_str_) => {
+                            fd.unassigned_properties.push(Property::new(
+                                http_headers.workload_name.to_string(), 
+                                join_str(&vec!["node", "metadata", "WORKLOAD_NAME", ]),
+                                property_str_.to_string()
+                            ));
+                        }
+                        Err(e) => { return Err(e.to_string()); }
+                    };
+                
+    
+             let property = http_headers
+                            .get_property(vec!["request", "total_size", ].to_vec())
+                            .ok_or_else(|| format!("Failed to retrieve property request.total_size."))?;
+            
+    let mut byte_array = [0u8; 8];                                      
+                for (place, element) in byte_array.iter_mut().zip(property.iter()) {
+                    *place = *element;                                              
+                }                                                                   
+                let int_val = i64::from_ne_bytes(byte_array);                       
+                fd.unassigned_properties.push(Property::new(
+                    http_headers.workload_name.to_string(), 
+                    join_str(&vec!["request", "total_size", ]),
+                    int_val.to_string() 
+                ));
+                
     
     return Ok(());
 }

--- a/example_queries/envoy/request_size_avg_trace_attr.rs.ref
+++ b/example_queries/envoy/request_size_avg_trace_attr.rs.ref
@@ -1,7 +1,8 @@
 // ---------------------- Generated Functions ----------------------------
 
-use super::filter_base::fetch_property;
 use super::filter_base::HttpHeaders;
+use super::filter_base::join_str;
+use proxy_wasm::traits::Context;
 use indexmap::IndexMap;
 use petgraph::graph::{Graph, NodeIndex};
 use utils::graph::graph_utils::generate_target_graph;
@@ -35,14 +36,39 @@ pub fn collect_envoy_properties(
     http_headers: &HttpHeaders,
     fd: &mut FerriedData,
 ) -> Result<(), String> {
-    let prop_tuple = fetch_property(&http_headers.workload_name,
-                                        &vec!["node", "metadata", "WORKLOAD_NAME", ],
-                                        http_headers)?;
-    fd.unassigned_properties.push(prop_tuple);
-    let prop_tuple = fetch_property(&http_headers.workload_name,
-                                        &vec!["request", "total_size", ],
-                                        http_headers)?;
-    fd.unassigned_properties.push(prop_tuple);
+    
+             let property = http_headers
+                            .get_property(vec!["node", "metadata", "WORKLOAD_NAME", ].to_vec())
+                            .ok_or_else(|| format!("Failed to retrieve property node.metadata.WORKLOAD_NAME."))?;
+            
+    
+                     let property_str = match std::str::from_utf8(&property) {
+                        Ok(property_str_) => {
+                            fd.unassigned_properties.push(Property::new(
+                                http_headers.workload_name.to_string(), 
+                                join_str(&vec!["node", "metadata", "WORKLOAD_NAME", ]),
+                                property_str_.to_string()
+                            ));
+                        }
+                        Err(e) => { return Err(e.to_string()); }
+                    };
+                
+    
+             let property = http_headers
+                            .get_property(vec!["request", "total_size", ].to_vec())
+                            .ok_or_else(|| format!("Failed to retrieve property request.total_size."))?;
+            
+    let mut byte_array = [0u8; 8];                                      
+                for (place, element) in byte_array.iter_mut().zip(property.iter()) {
+                    *place = *element;                                              
+                }                                                                   
+                let int_val = i64::from_ne_bytes(byte_array);                       
+                fd.unassigned_properties.push(Property::new(
+                    http_headers.workload_name.to_string(), 
+                    join_str(&vec!["request", "total_size", ]),
+                    int_val.to_string() 
+                ));
+                
     
     return Ok(());
 }

--- a/example_queries/envoy/request_time.rs.ref
+++ b/example_queries/envoy/request_time.rs.ref
@@ -26,8 +26,8 @@ pub fn create_target_graph() -> Graph<
         ids_to_properties.insert("a".to_string(), IndexMap::new());
         ids_to_properties.insert("b".to_string(), IndexMap::new());
         ids_to_properties.insert("c".to_string(), IndexMap::new());
-        let mut b_hashmap = ids_to_properties.get_mut("b").unwrap();
-        b_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "reviews-v1".to_string());
+        let mut c_hashmap = ids_to_properties.get_mut("c").unwrap();
+        c_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "ratings-v1".to_string());
         return generate_target_graph(vertices, edges, ids_to_properties);
 
 }
@@ -55,33 +55,17 @@ pub fn collect_envoy_properties(
                 
     
              let property = http_headers
-                            .get_property(vec!["request", "total_size", ].to_vec())
-                            .ok_or_else(|| format!("Failed to retrieve property request.total_size."))?;
+                            .get_property(vec!["request", "time", ].to_vec())
+                            .ok_or_else(|| format!("Failed to retrieve property request.time."))?;
             
     let mut byte_array = [0u8; 8];                                      
                 for (place, element) in byte_array.iter_mut().zip(property.iter()) {
                     *place = *element;                                              
                 }                                                                   
-                let int_val = i64::from_ne_bytes(byte_array);                       
+                let int_val = u64::from_ne_bytes(byte_array);                       
                 fd.unassigned_properties.push(Property::new(
                     http_headers.workload_name.to_string(), 
-                    join_str(&vec!["request", "total_size", ]),
-                    int_val.to_string() 
-                ));
-                
-    
-             let property = http_headers
-                            .get_property(vec!["request", "total_size", ].to_vec())
-                            .ok_or_else(|| format!("Failed to retrieve property request.total_size."))?;
-            
-    let mut byte_array = [0u8; 8];                                      
-                for (place, element) in byte_array.iter_mut().zip(property.iter()) {
-                    *place = *element;                                              
-                }                                                                   
-                let int_val = i64::from_ne_bytes(byte_array);                       
-                fd.unassigned_properties.push(Property::new(
-                    http_headers.workload_name.to_string(), 
-                    join_str(&vec!["request", "total_size", ]),
+                    join_str(&vec!["request", "time", ]),
                     int_val.to_string() 
                 ));
                 
@@ -95,24 +79,7 @@ pub fn execute_udfs_and_check_trace_lvl_prop(http_headers: &HttpHeaders, fd: &mu
     let root_id = "productpage-v1";
     
             if &http_headers.workload_name == root_id {        let mut trace_prop_str : String;
-
-                let root_node = get_node_with_id(&fd.trace_graph, "productpage-v1".to_string()).unwrap();
-                if ! ( fd.trace_graph.node_weight(root_node).unwrap().1.contains_key("request.total_size") &&
-                    fd.trace_graph.node_weight(root_node).unwrap().1["request.total_size"] == "1" ){
-                    // TODO:  replace fd
-                    match serde_json::to_string(&fd) {
-                        Ok(fd_str) => {
-                            return false;
-                        }
-                        Err(e) => {
-                            log::error!("could not serialize baggage {0}
-", e);
-                            return false;
-                        }
-                     }
-                     return false;
-                }
-                       }
+       }
     return true;
 }
 
@@ -151,13 +118,13 @@ pub fn get_value_for_storage(
             .node_weight(trace_node_idx)
             .unwrap()
             .1
-            .contains_key("request.total_size")
+            .contains_key("request.time")
         {
             // we have not yet collected the return property
-            log::error!("Missing return property request.total_size");
+            log::error!("Missing return property request.time");
             return None;
         }
-        let ret = &stored_data.trace_graph.node_weight(trace_node_idx).unwrap().1[ "request.total_size" ];
+        let ret = &stored_data.trace_graph.node_weight(trace_node_idx).unwrap().1[ "request.time" ];
 
         value = ret.to_string();
 

--- a/example_queries/join.cql
+++ b/example_queries/join.cql
@@ -1,4 +1,0 @@
-MATCH (a {service_name: "productpage-v1"}) -[]-> (b {service_name: "reviews-v1"}) RETURN a.request_size
-UNION
-MATCH (a {service_name: "productpage-v1"}) -[]-> (b {service_name: "reviews-v2"}) RETURN a.request_size
-

--- a/example_queries/request_size.cql
+++ b/example_queries/request_size.cql
@@ -1,1 +1,1 @@
-MATCH (a)-[]->(b)-[]->(c) WHERE c.node.metadata.WORKLOAD_NAME = 'ratings-v1' RETURN a.request.total_size as int
+MATCH (a)-[]->(b)-[]->(c) WHERE c.node.metadata.WORKLOAD_NAME = 'ratings-v1' RETURN a.request.total_size

--- a/example_queries/request_time.cql
+++ b/example_queries/request_time.cql
@@ -1,0 +1,1 @@
+MATCH (a)-[]->(b)-[]->(c) WHERE c.node.metadata.WORKLOAD_NAME = 'ratings-v1' RETURN a.request.time

--- a/example_queries/sim/request_time.rs.ref
+++ b/example_queries/sim/request_time.rs.ref
@@ -1,0 +1,428 @@
+use rpc_lib::rpc::Rpc;
+use indexmap::map::IndexMap;
+use petgraph::graph::{Graph, NodeIndex};
+use petgraph::Incoming;
+use utils::graph::graph_utils;
+use utils::graph::iso::find_mapping_shamir_centralized;
+use utils::graph::serde::FerriedData;
+use utils::graph::serde::Property;
+use log4rs::{
+    append::{
+        console::{ConsoleAppender, Target},
+        file::FileAppender,
+    },
+    config::{Appender, Config, Root},
+    encode::pattern::PatternEncoder,
+    filter::threshold::ThresholdFilter,
+};
+
+use serde::{Serialize, Deserialize};
+extern crate serde_json;
+
+pub type CodeletType = fn(&Filter, &Rpc) -> Option<Rpc>;
+fn log_setup() {                                                                
+    // Build a stderr logger.                                                   
+    let stderr = ConsoleAppender::builder()                                     
+        .encoder(Box::new(PatternEncoder::new("{h({l})}: {m}\n")))              
+        .target(Target::Stderr)                                                 
+        .build();                                                               
+    // Logging to log file.                                                     
+    let logfile = FileAppender::builder()                                       
+        // Pattern: https://docs.rs/log4rs/*/log4rs/encode/pattern/index.html   
+        .encoder(Box::new(PatternEncoder::new("{l}: {m}\n")))                   
+        .append(false)                                                          
+        .build("sim.log")                                                       
+        .unwrap();                                                              
+    // Log Trace level output to file where trace is the default level          
+    // and the programmatically specified level to stderr.                      
+    let config = Config::builder()                                              
+        .appender(Appender::builder().build("logfile", Box::new(logfile)))      
+        .appender(                                                              
+            Appender::builder()                                                 
+                .filter(Box::new(ThresholdFilter::new(log::LevelFilter::Info))) 
+                .build("stderr", Box::new(stderr)),                             
+        )                                                                       
+        .build(                                                                 
+            Root::builder()                                                     
+                .appender("logfile")                                            
+                .appender("stderr")                                             
+                .build(log::LevelFilter::Trace),                                
+        )                                                                       
+        .unwrap();                                                              
+    // Use this to change log levels at runtime.                                
+    // This means you can change the default log level to trace                 
+    // if you are trying to debug an issue and need more logs on then turn it off
+    // once you are done.                                                       
+    let _handle = log4rs::init_config(config);                                  
+}    
+
+
+fn put_ferried_data_in_hdrs(fd: &mut FerriedData, hdr: &mut IndexMap<String,String>) {
+    match serde_json::to_string(fd) {
+        Ok(stored_data_string) => {
+            hdr.insert("ferried_data".to_string(), stored_data_string);
+        }
+        Err(e) => {
+            log::error!("ERROR:  could not translate stored data to json string: {0}\n", e);
+        }
+    }
+}
+
+// user defined functions:
+
+
+pub fn create_target_graph() -> Graph<
+    (
+        std::string::String,
+        IndexMap<std::string::String, std::string::String>,
+    ),
+    (),
+> {
+     let vertices = vec!(  "a".to_string(), "b".to_string(), "c".to_string(),  );
+         let edges = vec!(   ("a".to_string(), "b".to_string() ),   ("b".to_string(), "c".to_string() ),   );
+         let mut ids_to_properties: IndexMap<String, IndexMap<String, String>> = IndexMap::new();
+         ids_to_properties.insert("a".to_string(), IndexMap::new());
+         ids_to_properties.insert("b".to_string(), IndexMap::new());
+         ids_to_properties.insert("c".to_string(), IndexMap::new());
+         let mut c_hashmap = ids_to_properties.get_mut("c").unwrap();
+         c_hashmap.insert("node.metadata.WORKLOAD_NAME".to_string(), "ratings-v1".to_string());
+         return graph_utils::generate_target_graph(vertices, edges, ids_to_properties);
+ 
+
+}
+
+pub fn collect_envoy_properties(
+    filter: &Filter,
+    fd: &mut FerriedData,
+) {
+    let mut prop_tuple: Property;
+    prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
+                                                   "node.metadata.WORKLOAD_NAME".to_string(),
+                                                   filter.filter_state["node.metadata.WORKLOAD_NAME"].clone());
+                                             fd.unassigned_properties.push(prop_tuple); prop_tuple = Property::new(filter.whoami.as_ref().unwrap().to_string(),
+                                                   "request.time".to_string(),
+                                                   filter.filter_state["request.time"].clone());
+                                             fd.unassigned_properties.push(prop_tuple); 
+}
+
+pub fn execute_udfs_and_check_trace_lvl_prop(filter: &Filter, fd: &mut FerriedData) -> bool{
+    
+    let root_id = "productpage-v1";
+    
+        if filter.whoami.as_ref().unwrap()== root_id {        let mut trace_prop_str : String;
+       }
+    return true;
+}
+
+pub fn get_value_for_storage(                                                   
+    target_graph: &Graph<                                                       
+        (                                                                       
+            std::string::String,                                                
+            IndexMap<std::string::String, std::string::String>,                 
+        ),                                                                      
+        (),                                                    
+    >,                                                                          
+    mapping: &Vec<(NodeIndex, NodeIndex)>,                                      
+    fd: &FerriedData,                                                  
+) -> Option<String> {
+    let mut value : String;
+    let node_ptr = graph_utils::get_node_with_id(target_graph, "a".to_string());
+    if node_ptr.is_none() {
+       log::warn!("Node a not found");
+            return None;
+    }
+    let mut trace_node_index = None;
+    for map in mapping {
+        if target_graph.node_weight(map.0).unwrap().0 == "a" {
+            trace_node_index = Some(map.1);
+            break;
+        }
+    }
+    if trace_node_index == None || !&fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1.contains_key("request.time") {
+        // we have not yet collected the return property or have a mapping error
+        return None;
+    }
+    let mut ret = &fd.trace_graph.node_weight(trace_node_index.unwrap()).unwrap().1[ "request.time" ];
+
+    value = ret.to_string();
+ 
+    return Some(value);
+
+}
+
+#[derive(Clone, Debug)]
+pub struct Filter {
+    pub whoami: Option<String>,
+    pub target_graph: Option<Graph<(String, IndexMap<String, String>), ()>>,
+    pub filter_state: IndexMap<String, String>,
+    pub envoy_shared_data: IndexMap<String, String>, // trace ID to stored ferried data as string 
+    pub collected_properties: Vec<String>, //properties to collect
+}
+
+impl Filter {
+    #[no_mangle]
+    pub fn new() -> *mut Filter {
+         log_setup();
+         Box::into_raw(Box::new(Filter {
+            whoami: None,
+            target_graph: None,
+            filter_state: IndexMap::new(),
+            envoy_shared_data: IndexMap::<String, String>::new(),
+            collected_properties: vec!(  ),
+         }))
+    }
+
+    #[no_mangle]
+    pub fn new_with_envoy_properties(string_data: IndexMap<String, String>) -> *mut Filter {
+        log_setup();
+        Box::into_raw(Box::new(Filter {
+                                   whoami: None,
+                                   target_graph: None,
+                                   filter_state: string_data,
+                                   envoy_shared_data: IndexMap::new(),
+                                   collected_properties: vec!( ),
+                               }))
+     }
+
+    pub fn init_filter(&mut self) {
+        if self.whoami.is_none() { self.set_whoami(); assert!(self.whoami.is_some()); }
+        if self.target_graph.is_none() { self.target_graph = Some(create_target_graph()); } 
+        assert!(self.whoami.is_some());
+    }
+
+    pub fn set_whoami(&mut self) {
+        if !self.filter_state.contains_key("node.metadata.WORKLOAD_NAME") {
+            log::warn!("filter was initialized without envoy properties and thus cannot function");
+            return;
+        }
+        let my_node = self
+            .filter_state["node.metadata.WORKLOAD_NAME"].clone();
+        self.whoami = Some(my_node);
+        assert!(self.whoami.is_some());
+    }
+
+    pub fn store_headers(&mut self, uid_64: u64, headers: IndexMap<String,String>) {
+        // If you don't have data, nothing to store
+        if !headers.contains_key("ferried_data") { 
+            log::warn!("no ferried data\n");
+            return;
+        }
+        let uid = uid_64.to_string();
+        // If there is no data stored, you needn't merge - just throw it in
+        if !self.envoy_shared_data.contains_key(&uid) {
+            self.envoy_shared_data.insert(uid.clone(), headers["ferried_data"].clone());
+        }
+
+        // Else, we merge in 2 parts, for each of the struct values
+        let mut data: FerriedData;
+        let mut stored_data: FerriedData;
+
+        match serde_json::from_str(&headers["ferried_data"]) {
+            Ok(d) => { data = d; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+        match serde_json::from_str(&self.envoy_shared_data[&uid]) {
+            Ok(d) => { stored_data = d; }
+            Err(e) => { log::error!("could not parse envoy shared data: {0}\n", e); return; }
+        }
+
+
+        // 2. Merge the graphs by simply adding it - later, when we merge, we will
+        //    make a root
+
+        // add node
+        for node in data.trace_graph.node_indices() {
+            stored_data.trace_graph.add_node(data.trace_graph.node_weight(node).unwrap().clone());
+        }
+        // add edges
+        for edge in data.trace_graph.edge_indices() {
+            match data.trace_graph.edge_endpoints(edge) {
+                Some((edge0, edge1)) => {
+                    let edge0_weight = &data.trace_graph.node_weight(edge0).unwrap().0;
+                    let edge1_weight = &data.trace_graph.node_weight(edge1).unwrap().0;
+                    let edge0_in_stored_graph = graph_utils::get_node_with_id(&stored_data.trace_graph, edge0_weight.to_string()).unwrap();
+                    let edge1_in_stored_graph = graph_utils::get_node_with_id(&stored_data.trace_graph, edge1_weight.to_string()).unwrap();
+                    stored_data.trace_graph.add_edge(edge0_in_stored_graph, edge1_in_stored_graph, ());
+                }
+                None => {
+                    log::error!("no edge endpoints found \n");
+                    return;
+                }
+            }
+        }
+
+        // 3. merge unassigned properties
+        //    these are properties we have collected but are not yet in the graph
+        stored_data.unassigned_properties.append(&mut data.unassigned_properties);
+        stored_data.unassigned_properties.sort_unstable();
+        stored_data.unassigned_properties.dedup();
+        stored_data.assign_properties();
+
+        match serde_json::to_string(&stored_data) {
+            Ok(stored_data_string) => {
+                self.envoy_shared_data.insert(uid, stored_data_string);
+            }
+            Err(e) => {
+                log::error!("could not translate stored data to json string: {0}\n", e);
+            }
+        }
+
+    }
+
+    pub fn merge_headers(&mut self, uid: u64, mut new_rpc_headers: IndexMap<String, String>) -> IndexMap<String, String> {
+        let uid_str = uid.to_string();
+        let mut my_indexmap = IndexMap::new();
+        my_indexmap.insert("node.metadata.WORKLOAD_NAME".to_string(), self.whoami.as_ref().unwrap().clone());
+
+        if self.envoy_shared_data.contains_key(&uid_str) {
+            match serde_json::from_str(&self.envoy_shared_data[&uid_str]) {
+                Ok(d) => {
+                    // 1. TODO:  if needed, do things to set S
+                    // 2. If response, add yourself as root
+                    if new_rpc_headers["direction"] == "response" {
+                        let mut data: FerriedData = d;
+                        let mut previous_roots = Vec::new();
+                        for node in data.trace_graph.node_indices() {
+                            if data.trace_graph.neighbors_directed(node, Incoming).count() == 0 {
+                                previous_roots.push(node);
+                            }
+                        }
+                        let me = data.trace_graph.add_node(
+                            (self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+    
+                        for previous_root in previous_roots {
+                            data.trace_graph.add_edge(me, previous_root, ());
+                        }
+                        data.assign_properties();
+
+                        // Finally, put all the data back in the headers
+                        put_ferried_data_in_hdrs(&mut data, &mut new_rpc_headers);
+                    }
+                }
+                Err(e) => {
+                    log::error!("could not parse envoy shared data: {0}\n", e);
+                }
+
+            }
+        } else {
+            let mut new_ferried_data = FerriedData::default();
+            new_ferried_data.trace_graph.add_node((self.whoami.as_ref().unwrap().to_string(), my_indexmap));
+            put_ferried_data_in_hdrs(&mut new_ferried_data, &mut new_rpc_headers);
+        }
+        return new_rpc_headers;
+    }
+
+    pub fn on_incoming_requests(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        // Fetch ferried data
+        let mut ferried_data: FerriedData;
+        if !x.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&x.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => {
+                    log::error!("could not translate stored data to json string: {0}\n", e);
+                    return vec![x];
+                }
+            }
+        }
+
+        // Insert properties to collect
+        collect_envoy_properties(self, &mut ferried_data);
+
+        // Return ferried data to x, and store headers
+        put_ferried_data_in_hdrs(&mut ferried_data, &mut x.headers);
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
+    }
+
+    pub fn on_outgoing_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        // 0. Look up stored baggage, and merge it
+        x.headers = self.merge_headers(x.uid, x.headers);
+
+        // at most, we return two rpcs:  one to continue on and one to storage
+        let mut original_rpc = x.clone();
+        let mut storage_rpc : Rpc;
+
+        // 1. retrieve our ferried data, containing the newly merged
+        //    baggage
+        let mut ferried_data: FerriedData;
+        if !original_rpc.headers.contains_key("ferried_data") {
+            ferried_data = FerriedData::default();
+        } else {
+            match serde_json::from_str(&mut original_rpc.headers["ferried_data"]) {
+                Ok(fd) => { ferried_data = fd; }
+                Err(e) => { log::error!("could not parse ferried data: {0}\n", e); return vec![original_rpc]; }
+            }
+        }
+
+        let root_id = "productpage-v1";
+        let trace_prop_sat = execute_udfs_and_check_trace_lvl_prop(self, &mut ferried_data);
+        // 3. perform isomorphism and possibly return if root node
+        if trace_prop_sat && self.whoami.as_ref().unwrap() == root_id {
+            let mapping = find_mapping_shamir_centralized(
+                &ferried_data.trace_graph,
+                self.target_graph.as_ref().unwrap(),
+            );
+            if mapping.is_some() {
+                let m = mapping.unwrap();
+                let value = get_value_for_storage(self.target_graph.as_ref().unwrap(), &m, &ferried_data);
+                if value.is_none() {
+                    put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+                    return vec![original_rpc];
+                }
+                // Now you have the return value, so
+                // 3a. Make a storage rpc
+                storage_rpc = Rpc::new_with_src(&value.unwrap(), self.whoami.as_ref().unwrap());
+                storage_rpc
+                    .headers
+                    .insert("dest".to_string(), "storage".to_string());
+                storage_rpc
+                    .headers
+                    .insert("direction".to_string(), "request".to_string());
+                storage_rpc.headers.insert("src".to_string(), self.whoami.clone().unwrap());
+
+                // 3b. Put baggage into regular rpc
+                put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+                return vec![original_rpc, storage_rpc];
+            }
+       }
+       put_ferried_data_in_hdrs(&mut ferried_data, &mut original_rpc.headers);
+       return vec![original_rpc];
+    }
+
+    pub fn on_outgoing_requests(&mut self, mut x: Rpc) -> Vec<Rpc>{
+        x.headers = self.merge_headers(x.uid, x.headers);
+        return vec![x];
+    }
+
+    pub fn on_incoming_responses(&mut self, mut x: Rpc) -> Vec<Rpc> {
+        self.store_headers(x.uid, x.headers.clone());
+        return vec![x];
+    }
+
+
+    #[no_mangle]
+    pub fn execute(&mut self, x: &Rpc) -> Vec<Rpc> {
+        self.init_filter();
+        assert!(self.whoami.is_some());
+        match x.headers["direction"].as_str() {
+            "request" => {
+                 match x.headers["location"].as_str() {
+                 "ingress" => { return self.on_incoming_requests(x.clone()); }
+                 "egress" => { return self.on_outgoing_requests(x.clone()); }
+                 _ => { panic!("Filter got an rpc with no location\n"); }
+                 }
+             }
+             "response" => {
+                 match x.headers["location"].as_str() {
+                 "ingress" => { return self.on_incoming_responses(x.clone()); }
+                 "egress" => { return self.on_outgoing_responses(x.clone()); }
+                 _ => { panic!("Filter got an rpc with no location\n"); }
+                 }
+             }
+             _ => { panic!("Filter got an rpc with no direction\n"); }
+        }
+    }
+
+}

--- a/filter_envoy/filter_base.rs
+++ b/filter_envoy/filter_base.rs
@@ -102,41 +102,6 @@ fn fetch_data_from_headers(ctx: &HttpHeaders, request_type: HttpType) -> Ferried
     return FerriedData::default();
 }
 
-pub fn fetch_property(
-    node_name: &str,
-    prop_query: &Vec<&str>,
-    ctx: &HttpHeaders,
-) -> Result<Property, String> {
-    // Insert properties to collect
-    let prop_tuple;
-    // Seems like we need a copy here, a little bit annoying
-    let property = ctx
-        .get_property(prop_query.to_vec())
-        .ok_or_else(|| format!("Failed to retrieve property {:?}.", prop_query))?;
-    let property_str = match std::str::from_utf8(&property) {
-        Ok(property_str_) => property_str_.to_string(),
-        Err(_err) => {
-            // Some values are stored as integers
-            // Try this, but we may get nonsense.
-            // TODO: Explicit types and casting
-            // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
-            let mut byte_array = [0u8; 8];
-            for (place, element) in byte_array.iter_mut().zip(property.iter()) {
-                *place = *element;
-            }
-            let int_val = i64::from_ne_bytes(byte_array);
-            int_val.to_string()
-        }
-    };
-    //TODO: Adjust the format of this property
-    prop_tuple = Property::new(
-        node_name.to_string(),
-        join_str(prop_query),
-        property_str.clone(),
-    );
-    return Ok(prop_tuple);
-}
-
 fn get_shared_data(trace_id: &str, ctx: &HttpHeaders) -> Option<FerriedData> {
     let mut stored_data: FerriedData = FerriedData::default();
     if let (Some(data), _) = ctx.get_shared_data(&trace_id) {

--- a/src/codegen_envoy.rs
+++ b/src/codegen_envoy.rs
@@ -244,7 +244,6 @@ fn generate_property_blocks(
             property_str = property.to_dot_string());
         property_blocks.push(get_prop_block);
         let dot_str = property.to_dot_string();
-        log::warn!("dot str is {:?}", dot_str);
         match property_to_type[dot_str.as_str()] {
             "int" => {
                 let cast_block = format!("let mut byte_array = [0u8; 8];                                      
@@ -296,7 +295,7 @@ fn generate_property_blocks(
                 property_blocks.push(cast_block.to_string());
             }
             "Map" => {
-                // TODO
+                log::error!("Maps have not yet been implemented in the Rust wasm SDK;  they give an \" envoy assert panic: not implemented error\".  Until they are implemented in the SDK, they cannot be implemented here.");
             }
             "Timestamp" => {
                 // both timestamp and duration are approximated to nanoseconds
@@ -330,12 +329,10 @@ fn generate_property_blocks(
                 property_blocks.push(cast_block.to_string());
             }
             "metadata" => {
-                // TODO
-
+                log::error!("metadata by itself is not supported.  You must specify some property of metadata");
             }
             "Node" => {
-                // TODO
-
+                log::error!("node by itself is not supported.  You must specify some property of node");
             }
             _ => {
                 // when in doubt, it's a string

--- a/src/codegen_envoy.rs
+++ b/src/codegen_envoy.rs
@@ -222,7 +222,7 @@ fn make_aggr_block(agg: &Aggregate, query_data: &VisitorResults) -> String {
 fn generate_property_blocks(
     properties: &IndexSet<Property>,
     scalar_udf_table: &IndexMap<String, ScalarUdf>,
-    property_to_type: &IndexMap<&str, &str>
+    property_to_type: &IndexMap<&str, &str>,
 ) -> Vec<String> {
     // TODO:  here, we can have duplicates because they have different entities,
     // but we still just need to collect one version of the property
@@ -246,7 +246,8 @@ fn generate_property_blocks(
         let dot_str = property.to_dot_string();
         match property_to_type[dot_str.as_str()] {
             "int" => {
-                let cast_block = format!("let mut byte_array = [0u8; 8];                                      
+                let cast_block = format!(
+                    "let mut byte_array = [0u8; 8];                                      
                 for (place, element) in byte_array.iter_mut().zip(property.iter()) {{
                     *place = *element;                                              
                 }}                                                                   
@@ -256,12 +257,14 @@ fn generate_property_blocks(
                     join_str(&{property}),
                     int_val.to_string() 
                 ));
-                ", property = property.as_vec_str());
+                ",
+                    property = property.as_vec_str()
+                );
                 property_blocks.push(cast_block.to_string());
-
             }
             "uint" => {
-                let cast_block = format!("let mut byte_array = [0u8; 8];                                      
+                let cast_block = format!(
+                    "let mut byte_array = [0u8; 8];                                      
                 for (place, element) in byte_array.iter_mut().zip(property.iter()) {{
                     *place = *element;                                              
                 }}                                                                   
@@ -271,13 +274,16 @@ fn generate_property_blocks(
                     join_str(&{property}),
                     int_val.to_string() 
                 ));
-                ", property = property.as_vec_str());
+                ",
+                    property = property.as_vec_str()
+                );
                 property_blocks.push(cast_block.to_string());
             }
             "bool" => {
                 // This has no practical purpose right now, because the only boolean value isn't available on request
                 // However, it's good to have in case they add more properties in future
-                let cast_block = format!("let mut byte_array = [0u8; 8];                                      
+                let cast_block = format!(
+                    "let mut byte_array = [0u8; 8];                                      
                 for (place, element) in byte_array.iter_mut().zip(property.iter()) {{
                     *place = *element;                                              
                 }}                                                                   
@@ -291,7 +297,9 @@ fn generate_property_blocks(
                     join_str(&{property}),
                     bool_val.to_string() 
                 ));
-                ", property = property.as_vec_str());
+                ",
+                    property = property.as_vec_str()
+                );
                 property_blocks.push(cast_block.to_string());
             }
             "Map" => {
@@ -299,7 +307,8 @@ fn generate_property_blocks(
             }
             "Timestamp" => {
                 // both timestamp and duration are approximated to nanoseconds
-                let cast_block = format!("let mut byte_array = [0u8; 8];                                      
+                let cast_block = format!(
+                    "let mut byte_array = [0u8; 8];                                      
                 for (place, element) in byte_array.iter_mut().zip(property.iter()) {{
                     *place = *element;                                              
                 }}                                                                   
@@ -309,13 +318,15 @@ fn generate_property_blocks(
                     join_str(&{property}),
                     int_val.to_string() 
                 ));
-                ", property = property.as_vec_str());
+                ",
+                    property = property.as_vec_str()
+                );
                 property_blocks.push(cast_block.to_string());
-
             }
             "Duration" => {
                 // both timestamp and duration are approximated to nanoseconds
-                let cast_block = format!("let mut byte_array = [0u8; 8];                                      
+                let cast_block = format!(
+                    "let mut byte_array = [0u8; 8];                                      
                 for (place, element) in byte_array.iter_mut().zip(property.iter()) {{
                     *place = *element;                                              
                 }}                                                                   
@@ -325,18 +336,23 @@ fn generate_property_blocks(
                     join_str(&{property}),
                     int_val.to_string() 
                 ));
-                ", property = property.as_vec_str());
+                ",
+                    property = property.as_vec_str()
+                );
                 property_blocks.push(cast_block.to_string());
             }
             "metadata" => {
                 log::error!("metadata by itself is not supported.  You must specify some property of metadata");
             }
             "Node" => {
-                log::error!("node by itself is not supported.  You must specify some property of node");
+                log::error!(
+                    "node by itself is not supported.  You must specify some property of node"
+                );
             }
             _ => {
                 // when in doubt, it's a string
-                let cast_block = format!("
+                let cast_block = format!(
+                    "
                      let property_str = match std::str::from_utf8(&property) {{
                         Ok(property_str_) => {{
                             fd.unassigned_properties.push(Property::new(
@@ -347,12 +363,11 @@ fn generate_property_blocks(
                         }}
                         Err(e) => {{ return Err(e.to_string()); }}
                     }};
-                ", property = property.as_vec_str());
+                ",
+                    property = property.as_vec_str()
+                );
                 property_blocks.push(cast_block.to_string());
-                
             }
-
-
         }
     }
     property_blocks
@@ -415,7 +430,7 @@ fn generate_udf_blocks(
 pub fn generate_code_blocks(query_data: VisitorResults, udf_paths: Vec<String>) -> CodeStruct {
     // TODO: dynamically retrieve this from https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
 
-    let property_to_type : IndexMap<&str, &str> = [
+    let property_to_type: IndexMap<&str, &str> = [
         ("request.path", "String"),
         ("request.url_path", "String"),
         ("request.host", "String"),
@@ -443,7 +458,7 @@ pub fn generate_code_blocks(query_data: VisitorResults, udf_paths: Vec<String>) 
         ("destination.address", "String"),
         ("destination.port", "int"),
         ("connection.id", "uint"),
-        ("connection.mlts", "bool"),// More strings here
+        ("connection.mlts", "bool"), // More strings here
         ("upstream.port", "int"),
         ("metadata", "metadata"), // and more strings here
         ("filter_state", "Map"),
@@ -453,8 +468,11 @@ pub fn generate_code_blocks(query_data: VisitorResults, udf_paths: Vec<String>) 
         ("listener_metadata", "metadata"),
         ("route_metadata", "metadata"),
         ("upstream_host_metadata", "metadata"),
-        ("node.metadata.WORKLOAD_NAME", "String")
-    ].iter().cloned().collect();
+        ("node.metadata.WORKLOAD_NAME", "String"),
+    ]
+    .iter()
+    .cloned()
+    .collect();
     let mut code_struct = CodeStruct::new(&query_data.root_id);
     let mut scalar_udf_table: IndexMap<String, ScalarUdf> = IndexMap::new();
     // where we store udf implementations

--- a/src/codegen_envoy.rs
+++ b/src/codegen_envoy.rs
@@ -276,18 +276,58 @@ fn generate_property_blocks(
                 property_blocks.push(cast_block.to_string());
             }
             "bool" => {
-                // TODO
+                // This has no practical purpose right now, because the only boolean value isn't available on request
+                // However, it's good to have in case they add more properties in future
+                let cast_block = format!("let mut byte_array = [0u8; 8];                                      
+                for (place, element) in byte_array.iter_mut().zip(property.iter()) {{
+                    *place = *element;                                              
+                }}                                                                   
+                let int_val = u64::from_ne_bytes(byte_array);                       
+                let bool_val = false;
+                if int_val != 0 {{
+                    bool_val = true;
+                }}
+                fd.unassigned_properties.push(Property::new(
+                    http_headers.workload_name.to_string(), 
+                    join_str(&{property}),
+                    bool_val.to_string() 
+                ));
+                ", property = property.as_vec_str());
+                property_blocks.push(cast_block.to_string());
             }
             "Map" => {
                 // TODO
             }
             "Timestamp" => {
-                // TODO
+                // both timestamp and duration are approximated to nanoseconds
+                let cast_block = format!("let mut byte_array = [0u8; 8];                                      
+                for (place, element) in byte_array.iter_mut().zip(property.iter()) {{
+                    *place = *element;                                              
+                }}                                                                   
+                let int_val = u64::from_ne_bytes(byte_array);                       
+                fd.unassigned_properties.push(Property::new(
+                    http_headers.workload_name.to_string(), 
+                    join_str(&{property}),
+                    int_val.to_string() 
+                ));
+                ", property = property.as_vec_str());
+                property_blocks.push(cast_block.to_string());
 
             }
             "Duration" => {
-                // TODO
-
+                // both timestamp and duration are approximated to nanoseconds
+                let cast_block = format!("let mut byte_array = [0u8; 8];                                      
+                for (place, element) in byte_array.iter_mut().zip(property.iter()) {{
+                    *place = *element;                                              
+                }}                                                                   
+                let int_val = u64::from_ne_bytes(byte_array);                       
+                fd.unassigned_properties.push(Property::new(
+                    http_headers.workload_name.to_string(), 
+                    join_str(&{property}),
+                    int_val.to_string() 
+                ));
+                ", property = property.as_vec_str());
+                property_blocks.push(cast_block.to_string());
             }
             "metadata" => {
                 // TODO

--- a/templates/distributed_envoy_filter.rs.handlebars
+++ b/templates/distributed_envoy_filter.rs.handlebars
@@ -1,8 +1,9 @@
 // ---------------------- Generated Functions ----------------------------
 
-use super::filter_base::fetch_property;
 use super::filter_base::HttpHeaders;
 use super::filter_base::FerriedData;
+use super::filter_base::join_str;
+use proxy_wasm::traits::Context;
 use indexmap::IndexMap;
 use petgraph::graph::{Graph, NodeIndex};
 use utils::graph::graph_utils::generate_target_graph;

--- a/templates/envoy_filter.rs.handlebars
+++ b/templates/envoy_filter.rs.handlebars
@@ -1,6 +1,5 @@
 // ---------------------- Generated Functions ----------------------------
 
-use super::filter_base::fetch_property;
 use super::filter_base::HttpHeaders;
 use super::filter_base::join_str;
 use proxy_wasm::traits::Context;

--- a/templates/envoy_filter.rs.handlebars
+++ b/templates/envoy_filter.rs.handlebars
@@ -2,6 +2,8 @@
 
 use super::filter_base::fetch_property;
 use super::filter_base::HttpHeaders;
+use super::filter_base::join_str;
+use proxy_wasm::traits::Context;
 use indexmap::IndexMap;
 use petgraph::graph::{Graph, NodeIndex};
 use utils::graph::graph_utils::generate_target_graph;

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -11,6 +11,8 @@ use test_case::test_case; // Parametrized tests
 #[test_case("histogram.cql", vec!["histogram.rs"]; "inconclusive - histogram")]
 #[test_case("request_size.cql", vec![]; "request_size")]
 #[test_case("request_size_avg.cql", vec!["avg.rs"]; "request_size_avg")]
+#[test_case("request_size_avg_trace_attr.cql", vec!["avg.rs"]; "request_size_avg_trace_attr")]
+#[test_case("request_time.cql", vec![]; "request_time")]
 #[test_case("latency.cql", vec!["latency.rs"]; "inconclusive - latency")]
 fn check_compilation_envoy(
     query_name: &str,
@@ -69,6 +71,7 @@ fn check_compilation_envoy(
 #[test_case("request_size.cql", vec![]; "request_size")]
 #[test_case("request_size_avg.cql", vec!["avg.rs"]; "request_size_avg")]
 #[test_case("request_size_avg_trace_attr.cql", vec!["avg.rs"]; "request_size_avg_trace_attr")]
+#[test_case("request_time.cql", vec![]; "request_time")]
 #[test_case("latency.cql", vec!["latency.rs"]; "inconclusive - latency")]
 fn check_compilation_sim(
     query_name: &str,


### PR DESCRIPTION
This allows conversions between different types of Envoy attributes - String, int, uint, etc.  Unfortunately, some of the types aren't fully tested because either
1) As in the case of booleans, the only property that is a boolean isn't collected on the requests and so would be impossible to have in this situation anyway.  I put in code I think works though, in case more booleans are added to the Envoy attributes in future.  However, it's not tested because we can't pick up that property on requests.
2) Sometimes when you aren't specific enough, eg, say "a.node" or "a.metadata", Envoy does not know what information to give you and errors out - I put errors in the compiler to warn the user if they do that.
3) In the case of Maps, the Rust SDK apparently has not yet implemented the interface - I get a "critical	envoy assert	panic: not implemented" error when I try to access headers.  Hopefully they will get it in soon and then I can change the code on our end too.

Other than those three exceptions, all types are implemented.