### PR TITLE
custom antlr so that it works with nightly 1.55

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -30,6 +32,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -45,6 +49,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -63,6 +69,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/antlr4rust"]
+	path = libs/antlr4rust
+	url = git@github.com:dyn-tracing/antlr4rust.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 strum = "0.19"
 strum_macros = "0.19"
 indexmap = { version = "1.6.1", features = ["serde-1"] }
-antlr-rust = "=0.2"
+antlr-rust = { path = "./libs/antlr4rust" }
 input-stream = "0.3.0"
 
 [dev-dependencies]

--- a/src/codegen_envoy.rs
+++ b/src/codegen_envoy.rs
@@ -237,7 +237,7 @@ fn make_return_block(
                     &call.id,
                     id_to_property,
                 ),
-                _ => make_storage_rpc_value_from_target(&node, &call.id, id_to_property),
+                _ => make_storage_rpc_value_from_target(node, &call.id, id_to_property),
             }
         }
     }
@@ -250,7 +250,7 @@ fn make_aggr_block(
 ) -> String {
     let mut to_return = String::new();
     for arg in &agg.args {
-        to_return.push_str(&make_return_block(&arg, query_data, id_to_property));
+        to_return.push_str(&make_return_block(arg, query_data, id_to_property));
     }
     to_return
 }
@@ -559,7 +559,7 @@ pub fn generate_code_blocks(query_data: VisitorResults, udf_paths: Vec<String>) 
             make_return_block(entity_ref, &query_data, &code_struct.id_to_property)
         }
         IrReturnEnum::Aggregate(ref agg) => {
-            make_aggr_block(&agg, &query_data, &code_struct.id_to_property)
+            make_aggr_block(agg, &query_data, &code_struct.id_to_property)
         }
     };
     code_struct.response_blocks.push(resp_block);

--- a/src/codegen_simulator.rs
+++ b/src/codegen_simulator.rs
@@ -220,7 +220,7 @@ fn make_return_block(
                     &call.id,
                     id_to_property,
                 ),
-                _ => make_storage_rpc_value_from_target(&node, &call.id, id_to_property),
+                _ => make_storage_rpc_value_from_target(node, &call.id, id_to_property),
             }
         }
     }
@@ -233,7 +233,7 @@ fn make_aggr_block(
 ) -> String {
     let mut to_return = String::new();
     for arg in &agg.args {
-        to_return.push_str(&make_return_block(&arg, query_data, id_to_property));
+        to_return.push_str(&make_return_block(arg, query_data, id_to_property));
     }
     to_return
 }
@@ -362,7 +362,7 @@ pub fn generate_code_blocks(query_data: VisitorResults, udf_paths: Vec<String>) 
             make_return_block(entity_ref, &query_data, &code_struct.id_to_property)
         }
         IrReturnEnum::Aggregate(ref agg) => {
-            make_aggr_block(&agg, &query_data, &code_struct.id_to_property)
+            make_aggr_block(agg, &query_data, &code_struct.id_to_property)
         }
     };
     code_struct.response_blocks.push(resp_block);

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -100,7 +100,7 @@ impl Property {
         let mut lst_str = "vec![".to_string();
         for member in &self.members {
             lst_str.push('\"');
-            lst_str.push_str(&member);
+            lst_str.push_str(member);
             lst_str.push_str("\", ");
         }
         lst_str.push(']');
@@ -111,7 +111,7 @@ impl Property {
         let mut udf_str = String::new();
         if let Some((last, front)) = self.members.split_last() {
             for member in front {
-                udf_str.push_str(&member);
+                udf_str.push_str(member);
                 udf_str.push('.');
             }
             udf_str.push_str(last);


### PR DESCRIPTION
Previously, antlr only worked [with 1.53](https://github.com/rrevenantt/antlr4rust/issues/25).  I updated nightly, and it no longer worked because it had deprecated libraries, which were imported but not used.  I forked the repo and got rid of those deprecated libraries.