### PR TITLE
Set local toolchain to nightly

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Just a small quality of life change. There's [multiple ways](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) of setting a local toolchain but this way prevents new users from trying to compile on stable and getting a bunch of errors.